### PR TITLE
move TimeEnumMap definition into .cpp file to fix ODR violation

### DIFF
--- a/src/enum_mappers/time_enum_mappers.cpp
+++ b/src/enum_mappers/time_enum_mappers.cpp
@@ -2,6 +2,36 @@
 
 namespace oa::enum_mappers {
 
+/**
+ * Return the string to `DayCountRule` enum map.
+ */
+const auto& TimeEnumMap()
+{
+	static const std::unordered_map<std::string, time::DayCountRule> dc_map{
+		{"ACT/360", time::DayCountRule::kACT_360},
+		{"ACT:360", time::DayCountRule::kACT_360},
+		{"ACT_360", time::DayCountRule::kACT_360},
+		{"ACT360", time::DayCountRule::kACT_360},
+		{"30E/360", time::DayCountRule::k30_E_360_ISDA},
+		{"30E:360", time::DayCountRule::k30_E_360_ISDA},
+		{"30E_360", time::DayCountRule::k30_E_360_ISDA},
+		{"30E360", time::DayCountRule::k30_E_360_ISDA },
+		{"30/360", time::DayCountRule::k30_360_BOND_BASIS},
+		{"30:360", time::DayCountRule::k30_360_BOND_BASIS},
+		{"30_360", time::DayCountRule::k30_360_BOND_BASIS},
+		{"30360", time::DayCountRule::k30_360_BOND_BASIS},
+		{"30E/360EURO", time::DayCountRule::k30_360_E_EUROBOND},
+		{"30E:360EURO", time::DayCountRule::k30_360_E_EUROBOND},
+		{"30E_360EURO", time::DayCountRule::k30_360_E_EUROBOND},
+		{"30E360EURO", time::DayCountRule::k30_360_E_EUROBOND},
+		{"ACT/ACT", time::DayCountRule::kACT_ACT},
+		{"ACT:ACT", time::DayCountRule::kACT_ACT},
+		{"ACT_ACT", time::DayCountRule::kACT_ACT},
+		{"ACTACT", time::DayCountRule::kACT_ACT},
+	};
+	return dc_map;
+}
+
 	oa::time::DayCountRule MapInputToDayCountEnum(const std::string& input_str)
 	{
 		std::string key_str = input_str;

--- a/src/enum_mappers/time_enum_mappers.h
+++ b/src/enum_mappers/time_enum_mappers.h
@@ -11,35 +11,10 @@
 
 namespace oa::enum_mappers {
 
-	/**
-	 * Return the string to `DayCountRule` enum map.
-	 */
-	const auto& TimeEnumMap()
-	{
-		static const std::unordered_map<std::string, time::DayCountRule> dc_map{
-			{"ACT/360", time::DayCountRule::kACT_360},
-			{"ACT:360", time::DayCountRule::kACT_360},
-			{"ACT_360", time::DayCountRule::kACT_360},
-			{"ACT360", time::DayCountRule::kACT_360},
-			{"30E/360", time::DayCountRule::k30_E_360_ISDA},
-			{"30E:360", time::DayCountRule::k30_E_360_ISDA},
-			{"30E_360", time::DayCountRule::k30_E_360_ISDA},
-			{"30E360", time::DayCountRule::k30_E_360_ISDA },
-			{"30/360", time::DayCountRule::k30_360_BOND_BASIS},
-			{"30:360", time::DayCountRule::k30_360_BOND_BASIS},
-			{"30_360", time::DayCountRule::k30_360_BOND_BASIS},
-			{"30360", time::DayCountRule::k30_360_BOND_BASIS},
-			{"30E/360EURO", time::DayCountRule::k30_360_E_EUROBOND},
-			{"30E:360EURO", time::DayCountRule::k30_360_E_EUROBOND},
-			{"30E_360EURO", time::DayCountRule::k30_360_E_EUROBOND},
-			{"30E360EURO", time::DayCountRule::k30_360_E_EUROBOND},
-			{"ACT/ACT", time::DayCountRule::kACT_ACT},
-			{"ACT:ACT", time::DayCountRule::kACT_ACT},
-			{"ACT_ACT", time::DayCountRule::kACT_ACT},
-			{"ACTACT", time::DayCountRule::kACT_ACT},
-		};
-		return dc_map;
-	}
+/**
+ * Return the string to `DayCountRule` enum map.
+ */
+const auto& TimeEnumMap();
 
 	/// <summary>
 	/// returns an DayCountRule enum from a given string


### PR DESCRIPTION
Very dumb mistake that should have been caught earlier.

This at least verifies that the CMake build works; I probably missed it because I found this before I had completed the entire CMake build setup in #4, so maybe the partial configuration didn't build everything.