### PR TITLE
Update magic_enum include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,14 @@ cmake_minimum_required(VERSION 3.21)
 #       set if Boost is already installed in the system (e.g. through apt)
 #
 #   ODIN_MAGIC_ENUM_ROOT
-#       magic_enum install root
+#       magic_enum install root, i.e. should contain include directory.
 #
 #   ODIN_GTEST_ROOT
 #       Google Test install root. Can use GTEST_ROOT instead and does not need
 #       to be set if Google Test is already installed in the system
 #
 #   ODIN_EXCELSDK_ROOT
-#       Excel SDK install root, i.e. should contain INCLUDE, LIB diretories.
+#       Excel SDK install root, i.e. should contain INCLUDE, LIB directories.
 #       This need only be available for Windows builds and the user must use
 #       SAMPLES\MAKE.bat to build the samples, in particular frmwrk32.lib.
 #

--- a/cmake/FindDeps.cmake
+++ b/cmake/FindDeps.cmake
@@ -13,7 +13,7 @@ if(NOT DEFINED ODIN_MAGIC_ENUM_ROOT)
     message(FATAL_ERROR "ODIN_MAGIC_ENUM_ROOT not defined")
 endif()
 # otherwise, add to include directories (SYSTEM ignores warnings)
-include_directories(SYSTEM ${ODIN_MAGIC_ENUM_ROOT})
+include_directories(SYSTEM ${ODIN_MAGIC_ENUM_ROOT}/include)
 
 # minimum Boost version
 set(ODIN_BOOST_VERSION 1.71)


### PR DESCRIPTION
Updating the `magic_enum` include path used in the CMake config to use the `include` directory, not the root itself.

This was not clearly explained in the `CMakeLists.txt` comments. Also fixes some comment typos.