### PR TITLE
add local changes to date.cpp

### DIFF
--- a/src/time/date.cpp
+++ b/src/time/date.cpp
@@ -1,8 +1,25 @@
 #include "date.h"
 
+#include <chrono>
+#include <compare>
+#include <ctime>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <boost/algorithm/string.hpp>
+
+#include "helpers/utils.h"
+#include "oa/platform.h"
+#include "time/tenor.h"
+#include "time/time_enums.h"
+
+#if OA_HAS_CPP20_FORMAT
+#include <format>
+#endif  // !OA_HAS_CPP20_FORMAT
+
 namespace oa::time
 {
-
 
 	Date::Date(const int& year, const int& month, const int& day) : m_days_(day), m_months_(month), m_years_(year), m_julian_int_(ConvertToJulian(year, month, day))
 	{
@@ -16,22 +33,24 @@ namespace oa::time
 		if (oa::utils::CheckDateStr(date_str))
 		{
 			boost::split(split_date_str, date_str, boost::is_any_of("\\-\\/:"));
-			this->m_years_ = std::stoi(split_date_str.at(0)); 
-			this->m_months_ = std::stoi(split_date_str.at(1)); 
+			this->m_years_ = std::stoi(split_date_str.at(0));
+			this->m_months_ = std::stoi(split_date_str.at(1));
 			this->m_days_ = std::stoi(split_date_str.at(2));
 			this->m_julian_int_ = ConvertToJulian(m_years_, m_months_, m_days_);
 		}
 
 		else
 		{
-			throw "Invalid date string please check your string input!: " + date_str;
+			throw std::invalid_argument{
+				"Invalid date string please check your string input!: " + date_str
+			};
 		}
 
 	}
 
 	Date::Date(const int& julian_int) : m_julian_int_(julian_int)
 	{
-		std::tuple<int, int, int> results = this->ConvertToGregInt(julian_int);
+		std::tuple<int, int, int> results = ConvertToGregInt(julian_int);
 		PopulateYMDFromTuple(results);
 
 	}
@@ -50,23 +69,19 @@ namespace oa::time
 		this->m_days_ = std::get<2>(results);
 	}
 
-	std::tuple<int, int, int> Date::ConvertToGregInt(const std::chrono::system_clock::time_point& time_point) const
+	std::tuple<int, int, int> Date::ConvertToGregInt(
+		const std::chrono::system_clock::time_point& time_point)
 	{
-		auto days_point = floor<std::chrono::days> (time_point);
-		std::chrono::year_month_day ymd{ days_point };
-
-		//this will do an implicit cast of unsigned ints to int which is not ideal....  
-		auto year = static_cast<int> (ymd.year());
-		auto month = static_cast<unsigned> (ymd.month());
-		auto day = static_cast<unsigned> (ymd.day());
-			
-		return std::tuple<int, int, int>(year,month,day);
+		// convert to std::time_t integral time
+		auto c_time = std::chrono::system_clock::to_time_t(time_point);
+		// get pointer to std::tm in GMT (UTC) and return time tuple
+		auto c_tm = std::gmtime(&c_time);
+		return {1900 + c_tm->tm_year, 1 + c_tm->tm_mon, c_tm->tm_mday};
 	}
 
-	std::tuple<int, int, int> Date::ConvertToGregInt(const int & julian_day) const
+	std::tuple<int, int, int> Date::ConvertToGregInt(const int julian_day)
 	{
-			
-		int y = 4716, j = 1401, m = 2,   n = 12, r = 4,      p = 1461, 
+		int y = 4716, j = 1401, m = 2,   n = 12, r = 4,      p = 1461,
 			v = 3,    u = 5,    s = 153, w = 2,  B = 274277, C = -38;
 
 		int f = julian_day + j + (((4 * julian_day + B) / 146097) * 3) / 4 + C;
@@ -78,16 +93,14 @@ namespace oa::time
 		int computed_months = (((h / s) + m) % n) + 1;
 		int computed_years = (e / p) - y + (n + m - computed_months) / n;
 
-		std::tuple<int, int, int> ymd_result(computed_years, computed_months, computed_days);
-		return ymd_result;
+		return {computed_years, computed_months, computed_days};
 	}
-
 
 	int Date::ConvertToJulian(int year, int month, int day)
 	{
-		return (1461 *(year + 4800 + (month - 14) / 12)) / 4 + 
+		return (1461 *(year + 4800 + (month - 14) / 12)) / 4 +
 			(367 *(month - 2 - 12 *((month - 14) / 12))) / 12 -
-			(3 *((year + 4900 + (month - 14) / 12) / 100)) / 4 
+			(3 *((year + 4900 + (month - 14) / 12) / 100)) / 4
 			+ day - 32075;
 
 	}
@@ -107,15 +120,12 @@ namespace oa::time
 		return julian_date % 7;
 	}
 
-
-
-		
 	std::chrono::system_clock::time_point Date::ConvertToTimePt(void) const
 	{
 		return ConvertToTimePt(*this);
 	}
 
-	std::chrono::system_clock::time_point Date::ConvertToTimePt(const Date& given_date) 
+	std::chrono::system_clock::time_point Date::ConvertToTimePt(const Date& given_date)
 	{
 		std::tm time_point_result {};
 
@@ -132,9 +142,20 @@ namespace oa::time
 
 	std::string Date::ToString() const
 	{
-
-		return std::format("{}-{}-{} : Julian Integer = {}", std::to_string(m_years_),
-			std::to_string(m_months_), std::to_string(m_days_), std::to_string(m_julian_int_));
+#if OA_HAS_CPP20_FORMAT
+		return std::format(
+			"{}-{}-{} : Julian Integer = {}",
+			std::to_string(m_years_),
+			std::to_string(m_months_),
+			std::to_string(m_days_),
+			std::to_string(m_julian_int_)
+		);
+#else
+		return
+			std::to_string(m_years_) + "-" + std::to_string(m_months_) + "-" +
+			std::to_string(m_days_) + " : Julian Integer = " +
+			std::to_string(m_julian_int_);
+#endif  // !OA_HAS_CPP20_FORMAT
 	}
 
 	bool Date::IsLeap() const
@@ -148,7 +169,7 @@ namespace oa::time
 	}
 
 	int Date::DaysInMonth( int month, int year)
-	{	
+	{
 
 		if (month == 2)
 		{
@@ -159,7 +180,7 @@ namespace oa::time
 			return 30;
 		}
 
-		else 
+		else
 		{
 			return 31;
 		}
@@ -173,7 +194,7 @@ namespace oa::time
 	Date Date::AddTenor(const oa::time::Tenor& tenor) const
 	{
 		auto [lenght_of_time, tenor_enum] = tenor.GetValues();
-	
+
 		switch(tenor_enum)
 		{
 			case oa::time::Tenors::kDays:
@@ -206,8 +227,8 @@ namespace oa::time
 	Date Date::AddMonths(const int& time_length) const
 	{
 		int new_day(0), new_month(0), new_year(0);
-			
-		//compute the numbers of years 
+
+		//compute the numbers of years
 		if (time_length > 0)
 		{
 			new_year = m_years_ + (m_months_ + time_length) / 12;
@@ -224,7 +245,7 @@ namespace oa::time
 				new_year += -1;
 			}
 		}
-			
+
 		//check for when we add negative dates
 		if (new_month <= 0)
 		{
@@ -248,10 +269,10 @@ namespace oa::time
 		new_month = m_months_;
 		new_day = m_days_;
 
-		//if it is not leap year then check to see if this 
+		//if it is not leap year then check to see if this
 		if (!IsLeap(new_year) && (new_month == 2))
 		{
-			
+
 			new_day = (new_day > DaysInMonth(new_month, new_year)) ? DaysInMonth(new_month, new_year) : new_day;
 
 		}
@@ -279,7 +300,7 @@ namespace oa::time
 		return AddYears(-time_length);
 	}
 
-	//defining operator overlaoding 
+	// defining operator overloading
 	bool Date::operator==(const Date& right_value) const
 	{
 		return std::is_eq(m_julian_int_ <=> right_value.m_julian_int_);
@@ -289,5 +310,5 @@ namespace oa::time
 	{
 		return m_julian_int_ <=> right_value.m_julian_int_;
 	}
-	
-}
+
+}  // namespace oa::time


### PR DESCRIPTION
Local changes that were not pushed:

* fixed includes
* conditional include + use of `<format>` to support incomplete C++20 implementations
* updated `ConvertToGregInt` to not use C++20 `<chrono>` for portability
* strip unnecessary whitespace