### PR TITLE
update .gitignore to ignore VS and VS Code data dirs + builds dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /builds
 # ignore output directory from Visual Studio
 /out
+# ignore NuGet packages directory
+/packages


### PR DESCRIPTION
Modifies `.gitignore` so the `.vs`, `.vscode`, `builds` directories are ignored by Git.

`builds` is an artifact generated by Visual Studio. This has been updated to ignore some other directories too.