### PR TITLE
handle_prefix_test.cpp Google Test compatibility

### DIFF
--- a/src/unit_test/oxl/handle_prefixer_test.cpp
+++ b/src/unit_test/oxl/handle_prefixer_test.cpp
@@ -10,6 +10,7 @@
 
 #include <gtest/gtest.h>
 
+#include "oa/testing/gtest.h"
 #include "oxl/xl_api/cache_xl_obj.h"
 #include "oxl/xl_api/xl_array.h"
 #include "oxl/xl_api/xl_dictionary.h"


### PR DESCRIPTION
Includes the `oa/testing/gtest.h` header to pick up the Google Test compatibility macros defined there.

Previously the file would not compile for Google Test 1.8.x due to the `*_SUITE` suffixed macros only being introduced in around version 1.10.x, renamed from the original `*_CASE` macros, which are still defined for compatibility reasons.