### PR TITLE
use DllMain() to get oa_config module handle

### DIFF
--- a/src/config/paths.cpp
+++ b/src/config/paths.cpp
@@ -39,29 +39,54 @@
 namespace oa {
 namespace config {
 
+#ifdef _WIN32
+namespace {
+
+// DLL module handle. we set this on process attach in DllMain() so we don't
+// need to call GetModuleHandleA() for the config DLL's module handle
+HMODULE module_handle;
+
+}  // namespace
+
+}  // namespace config
+}  // namespace oa
+
+/**
+ * DLL entry point.
+ *
+ * Currently this is solely provided for `module_handle` initialization so we
+ * don't need to call `GetModuleHandleA()` to get the DLL module handle. This
+ * avoids needing to hardcode the DLL name into the source code.
+ *
+ * @note `DllMain()` need not have C linkage but must be in global namespace.
+ *
+ * @param hmod DLL module handle
+ * @param reason Reason for calling `DllMain()`
+ */
+BOOL WINAPI DllMain(HINSTANCE hmod, DWORD reason, LPVOID /*reserved*/)
+{
+  switch (reason) {
+  // on process attach we initialize module_handle
+  case DLL_PROCESS_ATTACH:
+    oa::config::module_handle = hmod;
+    break;
+  // in all other cases we don't need to do anything
+  default:
+    break;
+  }
+  return TRUE;
+}
+
+namespace oa {
+namespace config {
+#endif  // _WIN32
+
 std::filesystem::path library_path()
 {
 #if defined(_WIN32)
-  // get module handle for DLL
-  // note: when using the debug C runtime for debug builds we currently opt to
-  // build the library with a "d" suffix. this can be detected by checking if
-  // _DEBUG is defined which lets us correctly conditionally compile
-  // TODO: if we want to avoid hardcoding these names we can included a header
-  // configured by CMake that would have the DLL name
-#if defined(_DEBUG)
-  auto mod = GetModuleHandleA("oa_configd");
-#else
-  auto mod = GetModuleHandleA("oa_config");
-#endif  // _DEBUG
-  if (!mod)
-    throw std::system_error{
-      // note: cast required to avoid narrowing conversion from DWORD
-      {static_cast<int>(GetLastError()), std::system_category()},
-      OA_PRETTY_FUNCTION_NAME + std::string{": unable to get module handle"}
-    };
-  // get absolute path name
+  // get DLL absolute path name from module handle
   char name[MAX_PATH];
-  auto name_len = GetModuleFileNameA(mod, name, MAX_PATH);
+  auto name_len = GetModuleFileNameA(module_handle, name, MAX_PATH);
   // handle any errors
   if (!name_len)
     throw std::system_error{


### PR DESCRIPTION
## Summary

The Windows implementation for `oa::config::library_path()` uses [`GetModuleHandleA()`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulehandlea) which requires the name of the loaded DLL. Since the CMake config currently appends a "d" suffix to the name of static/shared libraries when building debug libraries, we previously used a `#ifdef _DEBUG` guard to ensure `GetModuleHandleA()` would be called with the correct DLL name.

However, this leads to complications if we chose to change the DLL output name (since the name is hardcoded in the `.cpp` file). We can, however, do better and avoid the use of `GetModuleHandleA()` by simply using the first argument of the [`DllMain()`](https://learn.microsoft.com/en-us/windows/win32/dlls/dllmain) entry point; this gives us the requisite module handle. Later, the [`GetModuleFileNameA()`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamea) call in `oa::config::library_path()` can then use this module handle to obtain the fully-qualified name of the `oa_config` DLL.