### PR TITLE
ensure windows.yml Boost install fails if depinst.py fails

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -41,6 +41,8 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04]
         # whether or not to use unity build
         unity: [off, on]
+      # keep running the rest of the matrix jobs even if one fails
+      fail-fast: false
     # job steps
     # note: runners have password-less sudo
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,6 +55,8 @@ jobs:
         arch: [Win32, x64]
         # whether or not to use unity build
         unity: [off, on]
+      # keep running the rest of the matrix jobs even if one fails
+      fail-fast: false
     # job steps
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Ensure that the Boost install stage in `windows.yml` fails if `depinst.py` is unable to correctly initialize the required Boost submodules for a given Boost module. Currently we don't do this, so the CMake stage still runs even if `depinst.py` wasn't able to correctly initialize the Boost submodules, which results in an incomplete Boost module installation.

Eventually, the build will error out because a required Boost header will be missing, but this makes the error more difficult to track down, as the root cause (incomplete Boost install, likely due to network timeout) is in an upstream stage.

Address a comment in #90 that mentions this problem as well as the [fail-fast discussion](https://github.com/Mjang714/OdinAnalytics/pull/90#issuecomment-3845677290).