### PR TITLE
add std::formatter specialization for fixed_string + enhance for MSVC

### DIFF
--- a/include/oa/features.h
+++ b/include/oa/features.h
@@ -1,0 +1,37 @@
+/**
+ * @file features.h
+ * @author Derek Huang
+ * @brief C/C++ header for feature checking
+ * @copyright MIT License
+ */
+
+#ifndef OA_FEATURES_H_
+#define OA_FEATURES_H_
+
+#include "oa/common.h"  // for OA_CPLUSPLUS
+
+// check if we are compiling under C++20 or above. always define when compiling
+// under C++ so we could use this in standard C++ expressions
+#ifdef OA_CPLUSPLUS
+#if OA_CPLUSPLUS >= 202002L
+#define OA_HAS_CXX20 1
+#endif  // OA_CPLUSPLUS >= 202002L
+#endif  // OA_CPLUSPLUS
+
+#ifndef OA_HAS_CXX20
+#define OA_HAS_CXX20 0
+#endif  // OA_HAS_CXX20
+
+// check if we have the C++20 <format> header. __has_include is standard since
+// C++17, available as compiler extension for C or earlier C++ standards
+#if defined(OA_CPLUSPLUS) && defined(__has_include)
+#if OA_HAS_CXX20 && __has_include(<format>)
+#define OA_HAS_CXX20_FORMAT 1
+#endif  // OA_CPLUSPLUS && __has_include(<format>)
+#endif  // !defined(OA_CPLUSPLUS) || !defined(__has_include)
+
+#ifndef OA_HAS_CXX20_FORMAT
+#define OA_HAS_CXX20_FORMAT 0
+#endif  // OA_HAS_CXX20_FORMAT
+
+#endif  // OA_FEATURES_H_

--- a/include/oa/fixed_string.h
+++ b/include/oa/fixed_string.h
@@ -8,10 +8,23 @@
 #ifndef OA_FIXED_STRING_H_
 #define OA_FIXED_STRING_H_
 
+// note: can include first as the header only defines macros
+#include "oa/features.h"
+
+// note: OA_HAS_CXX20_FORMAT headers only needed for std::formatter impl
+#if OA_HAS_CXX20_FORMAT
+#include <algorithm>
+#endif  // OA_HAS_CXX20_FORMAT
 #include <concepts>
 #include <cstddef>
+#if OA_HAS_CXX20_FORMAT
+#include <format>
+#endif  // OA_HAS_CXX20_FORMAT
 #include <limits>
 #include <ostream>
+#if OA_HAS_CXX20_FORMAT
+#include <sstream>
+#endif  // OA_HAS_CXX20_FORMAT
 #include <string>
 #include <type_traits>
 
@@ -495,5 +508,70 @@ auto& operator<<(std::ostream& out, const fixed_string<N>& str)
 }
 
 }  // namespace oa
+
+#if OA_HAS_CXX20_FORMAT
+namespace std {
+
+/**
+ * `std::formatter` specialization for the `fixed_string<N>`.
+ *
+ * The `fixed_string<N>` can be quoted if `#` is passed in the format spec.
+ * Otherwise, only missing or empty format specs are allowed, e.g. formatting
+ * with `"{}"` or `"{:}"` in a format string respectively.
+ *
+ * @tparam N Length of fixed string
+ */
+template <size_t N>
+struct formatter<oa::fixed_string<N>, char> {
+  /**
+   * Parse the incoming format specification to update formatter state.
+   *
+   * @param ctx Format specification parse context
+   */
+  constexpr auto parse(basic_format_parse_context<char>& ctx)
+  {
+    // format spec iterator
+    auto it = ctx.begin();
+    // empty format spec
+    if (it == ctx.end())
+      return it;
+    // if #, then indicate we will format using quotes
+    if (*it == '#') {
+      quote_ = true;
+      it++;
+    }
+    // error if format spec is not consumed
+    if (it != ctx.end() && *it != '}')
+      throw std::format_error{"invalid fixed_string format spec character"};
+    // ok, consumed what are able to parse
+    return it;
+  }
+
+  /**
+   * Format the `fixed_string<N>` into the formatting context.
+   *
+   * @tparam F `std::format_context<O, char>`
+   *
+   * @param str Fixed string to write
+   * @param ctx Formatting context
+   */
+  template <typename T>
+  auto format(const oa::fixed_string<N>& str, T& ctx) const
+  {
+    std::stringstream ss;
+    if (quote_)
+      ss << '"' << str << '"';
+    else
+      ss << str;
+    // copy moved string into out and return out iterator
+    return std::ranges::copy(std::move(ss).str(), ctx.out()).out;
+  }
+
+private:
+  bool quote_{};
+};
+
+}  // namespace std
+#endif  // OA_HAS_CXX20_FORMAT
 
 #endif  // OA_FIXED_STRING_H_

--- a/include/oa/fixed_string.h
+++ b/include/oa/fixed_string.h
@@ -220,8 +220,13 @@ public:
   template <std::same_as<char>... Ts>
   constexpr auto find(Ts... cs) const noexcept
   {
+    // note: use separate array for char pack since MSVC seems to have an issue
+    // with destroying initializer_list values too early, e.g. in this context
+    // where for (auto c : {cs...}) was used as the inner loop
+    const char ar[] = {cs...};
+    // search
     for (auto i = 0u; i < N; i++)
-      for (auto c : {cs...})
+      for (auto c : ar)
         if (data_[i] == c)
           return i;
     return npos;
@@ -239,8 +244,14 @@ public:
   template <std::same_as<char>... Ts>
   constexpr auto rfind(Ts... cs) const noexcept
   {
+    // note: use separate array for char pack since MSVC seems to have an issue
+    // with destroying initializer_list values too early, e.g. in this context
+    // where for (auto c : {cs...}) was used as the inner loop
+    const char ar[] = {cs...};
+    // search
     for (auto i = 0u; i < N; i++)
-      for (auto c : {cs...})
+      // for (auto c : ar)
+      for (auto c : ar)
         if (data_[N - i - 1u] == c)
           return N - i - 1u;
     return npos;

--- a/include/oa/platform.h
+++ b/include/oa/platform.h
@@ -8,31 +8,35 @@
 #ifndef OA_PLATFORM_H_
 #define OA_PLATFORM_H_
 
-// accurate C++ version integer, no need to use /Zc:__cplusplus with MSVC
-#if defined(_MSC_VER) && defined(_MSVC_LANG)
-#define OA_CPLUSPLUS _MSVC_LANG
-#elif defined(__cplusplus)
-#define OA_CPLUSPLUS __cplusplus
-#endif  // (!defined(_MSC_VER) || !defined(_MSVC_LANG)) && !defined(__cplusplus)
+#include "oa/common.h"
+
+// TODO: rename header to features.h as not all features are platform features
 
 // check if we are compiling under C++20 or above. always define when compiling
 // under C++ so we could use this in standard C++ expressions
 #ifdef OA_CPLUSPLUS
 #if OA_CPLUSPLUS >= 202002L
-#define OA_CPLUSPLUS_20 1
-#else
-#define OA_CPLUSPLUS_20 0
-#endif  // OA_CPLUSPLUS < 202002L
+#define OA_HAS_CXX20 1
+#endif  // OA_CPLUSPLUS >= 202002L
 #endif  // OA_CPLUSPLUS
+
+#ifndef OA_HAS_CXX20
+#define OA_HAS_CXX20 0
+#endif  // OA_HAS_CXX20
 
 // check if we have the C++20 <format> header. __has_include is standard since
 // C++17, available as compiler extension for C or earlier C++ standards
 #if defined(OA_CPLUSPLUS) && defined(__has_include)
-#if OA_CPLUSPLUS_20 && __has_include(<format>)
-#define OA_HAS_CPP20_FORMAT 1
-#else
-#define OA_HAS_CPP20_FORMAT 0
-#endif  // !OA_CPLUSPLUS || !__has_include(<format>)
+#if OA_HAS_CXX20 && __has_include(<format>)
+#define OA_HAS_CXX20_FORMAT 1
+#endif  // OA_CPLUSPLUS && __has_include(<format>)
 #endif  // !defined(OA_CPLUSPLUS) || !defined(__has_include)
+
+#ifndef OA_HAS_CXX20_FORMAT
+#define OA_HAS_CXX20_FORMAT 0
+#endif  // OA_HAS_CXX20_FORMAT
+
+// TODO: deprecate OA_HAS_CPP20_FORMAT and use OA_HAS_CXX20_FORMAT instead
+#define OA_HAS_CPP20_FORMAT OA_HAS_CXX20_FORMAT
 
 #endif  // OA_PLATFORM_H_

--- a/include/oa/platform.h
+++ b/include/oa/platform.h
@@ -8,33 +8,8 @@
 #ifndef OA_PLATFORM_H_
 #define OA_PLATFORM_H_
 
-#include "oa/common.h"
-
-// TODO: rename header to features.h as not all features are platform features
-
-// check if we are compiling under C++20 or above. always define when compiling
-// under C++ so we could use this in standard C++ expressions
-#ifdef OA_CPLUSPLUS
-#if OA_CPLUSPLUS >= 202002L
-#define OA_HAS_CXX20 1
-#endif  // OA_CPLUSPLUS >= 202002L
-#endif  // OA_CPLUSPLUS
-
-#ifndef OA_HAS_CXX20
-#define OA_HAS_CXX20 0
-#endif  // OA_HAS_CXX20
-
-// check if we have the C++20 <format> header. __has_include is standard since
-// C++17, available as compiler extension for C or earlier C++ standards
-#if defined(OA_CPLUSPLUS) && defined(__has_include)
-#if OA_HAS_CXX20 && __has_include(<format>)
-#define OA_HAS_CXX20_FORMAT 1
-#endif  // OA_CPLUSPLUS && __has_include(<format>)
-#endif  // !defined(OA_CPLUSPLUS) || !defined(__has_include)
-
-#ifndef OA_HAS_CXX20_FORMAT
-#define OA_HAS_CXX20_FORMAT 0
-#endif  // OA_HAS_CXX20_FORMAT
+// TODO: remove this header after refactoring to use features.h
+#include "oa/features.h"
 
 // TODO: deprecate OA_HAS_CPP20_FORMAT and use OA_HAS_CXX20_FORMAT instead
 #define OA_HAS_CPP20_FORMAT OA_HAS_CXX20_FORMAT

--- a/include/oa/testing/gtest.h
+++ b/include/oa/testing/gtest.h
@@ -309,6 +309,9 @@ auto make_result(bool res, const F& /*comp*/, const Ts&... values)
     auto make_failure = [prefix](const auto& v1, const auto& v2)
     {
       return ::testing::AssertionFailure() << prefix <<
+        // TODO: we actually want the *negation* of op_string. this can be done
+        // by adding another member but also we might want a way of defaulting
+        // the comparison using some function template
         v1 << " " << binary_format_traits<F>::op_string << " " << v2;
     };
     return make_failure(values...);

--- a/include/oa/testing/gtest.h
+++ b/include/oa/testing/gtest.h
@@ -282,6 +282,9 @@ auto& operator<<(std::ostream& out, const delimited<Ts...>& value)
  * @tparam F n-ary comparator
  * @tparam Ts Value types
  *
+ * @todo Extend to allow `res` to be a `::testing::AssertionResult` for more
+ *  customized error formatting compared to formatting true/false
+ *
  * @param res Result of `comp(values...)`
  * @param values Values comparator was invoked with
  */

--- a/include/oa/testing/gtest.h
+++ b/include/oa/testing/gtest.h
@@ -11,10 +11,12 @@
 #ifndef OA_TESTING_GTEST_H_
 #define OA_TESTING_GTEST_H_
 
+#include <concepts>
 #include <cstdlib>  // for OA_GTEST_ENSURE_BASE_DIR
 #include <functional>
 #include <iomanip>
 #include <ostream>
+#include <ranges>
 #include <string_view>
 #include <tuple>
 #include <type_traits>
@@ -24,6 +26,7 @@
 #include <boost/core/demangle.hpp>
 #include <gtest/gtest.h>
 
+#include "oa/warnings.h"
 // TODO: refactor include path when namespacing is implemented
 #include "time/date.h"
 
@@ -269,11 +272,13 @@ auto& operator<<(std::ostream& out, const delimited<Ts...>& value)
   return out;
 }
 
+namespace detail {
+
 /**
  * Format a `::testing::AssertionResult` based on the comparator and values.
  *
- * This supports arbitrary n-ary predicates with some special formatting
- * support for binary predicates like `std::equal_to`.
+ * This implements `::testing::AssertionResult` formatting for for arbitrary
+ * n-ary predicates that do not return a `::testing::AssertionResult`.
  *
  * @note This overload does not invoke the comparator at all and relies on the
  *  `res` value which should be the result of `comp(values...)`.
@@ -282,15 +287,12 @@ auto& operator<<(std::ostream& out, const delimited<Ts...>& value)
  * @tparam F n-ary comparator
  * @tparam Ts Value types
  *
- * @todo Extend to allow `res` to be a `::testing::AssertionResult` for more
- *  customized error formatting compared to formatting true/false
- *
  * @param res Result of `comp(values...)`
  * @param values Values comparator was invoked with
  */
-template <bool is_compile_time, typename F, typename... Ts>
-requires (std::is_invocable_r_v<bool, F, Ts...>)
-auto make_result(bool res, const F& /*comp*/, const Ts&... values)
+template <bool is_compile_time, typename R, typename F, typename... Ts>
+requires (std::is_invocable_r_v<R, F, Ts...> && std::is_convertible_v<R, bool>)
+auto make_result(R res, const F& /*comp*/, const Ts&... values)
 {
   // success, so no error message formatting
   if (res)
@@ -308,20 +310,52 @@ auto make_result(bool res, const F& /*comp*/, const Ts&... values)
     // assuming that the invocable really is a binary invocable
     auto make_failure = [prefix](const auto& v1, const auto& v2)
     {
-      return ::testing::AssertionFailure() << prefix <<
-        // TODO: we actually want the *negation* of op_string. this can be done
-        // by adding another member but also we might want a way of defaulting
-        // the comparison using some function template
+      return ::testing::AssertionFailure() << "result of: " << prefix <<
         v1 << " " << binary_format_traits<F>::op_string << " " << v2;
     };
     return make_failure(values...);
   }
   // otherwise, use generic RTTI-based invocable formatting
   else
-    return ::testing::AssertionFailure() << prefix <<
+    return ::testing::AssertionFailure() << "result of: " << prefix <<
       boost::core::demangle(typeid(F).name()) << "{}(" <<
       delimited{", ", values...} << ")";
 }
+
+}  // namespace detail
+
+// suppress C4100 to prevent explosion in messages per template instance
+OA_MSVC_WARNING_PUSH()
+OA_MSVC_WARNING_DISABLE(4100)
+/**
+ * Format a `::testing::AssertionResult` based on the comparator and values.
+ *
+ * This supports arbitrary n-ary predicates with some special formatting
+ * support for binary predicates like `std::equal_to`. If `comp(values...)`
+ * returns a `::testing::AssertionResult` the object is passed through.
+ *
+ * @note This overload does not invoke the comparator at all and relies on the
+ *  `res` value which should be the result of `comp(values...)`.
+ *
+ * @tparam is_compile_time `true` if `comp(values...)` invoked at compile time
+ * @tparam F n-ary comparator
+ * @tparam Ts Value types
+ *
+ * @param res Result of `comp(values...)`
+ * @param values Values comparator was invoked with
+ */
+template <bool is_compile_time, typename R, typename F, typename... Ts>
+requires (std::is_invocable_r_v<R, F, Ts...> && std::is_convertible_v<R, bool>)
+auto make_result(R res, const F& comp, const Ts&... values)
+{
+  // if AssertionResult itself just pass through
+  if constexpr (std::is_same_v<R, ::testing::AssertionResult>)
+    return std::move(res);
+  // otherwise check binary_format_traits<> and do generic formatting
+  else
+    return detail::make_result<is_compile_time>(std::move(res), comp, values...);
+}
+OA_MSVC_WARNING_POP()
 
 /**
  * Format a `::testing::AssertionResult` based on the comparator and values.
@@ -357,11 +391,65 @@ auto make_result(const F& comp, const Ts&... values)
  * @param comp Comparator object
  * @param values Values to invoke comparator on
  */
-template <bool res, typename F, typename... Ts>
-requires (std::is_invocable_r_v<bool, F, Ts...>)
+template <auto res, typename F, typename... Ts>
+requires (std::is_invocable_r_v<decltype(res), F, Ts...>)
 auto make_result(const F& comp, const Ts&... values)
 {
   return make_result<true>(res, comp, values...);
+}
+
+namespace detail {
+
+/**
+ * Concept for a string-like object.
+ *
+ * We simply check that the object is a contiguous range of char type.
+ *
+ * @note Unused in this header but could be useful in a formatting context.
+ *
+ * @tparam T type
+ */
+template <typename T>
+concept string_like = (
+  std::ranges::contiguous_range<T> &&
+  std::same_as<std::ranges::range_value_t<T>, char>
+);
+
+/**
+ * Concept for weak equality in one direction.
+ *
+ * This is a weaker form of `std::equality_comparable`.
+ *
+ * @tparam T First type
+ * @tparam U Second type
+ */
+template <typename T, typename U>
+concept weakly_equality_comparable = requires (T x, U y) {
+  { x == y } -> std::convertible_to<bool>;
+};
+
+}  // namespace detail
+
+/**
+ * Check that two values are equal and return a `::testing::AssertionResult`.
+ *
+ * This is useful for simple `x == y` testing with a default error message.
+ *
+ * @tparam T First type
+ * @tparam U Second type
+ *
+ * @param x First value
+ * @param y Second value
+ */
+template <typename T, typename U>
+requires (detail::weakly_equality_comparable<T, U>)
+auto eq(const T& x, const U& y)
+{
+  // perform equality check
+  if (x == y)
+    return ::testing::AssertionSuccess();
+  else
+    return ::testing::AssertionFailure() << x << " != " << y;
 }
 
 }  // namespace testing

--- a/src/unit_test/fixed_string_test.cpp
+++ b/src/unit_test/fixed_string_test.cpp
@@ -339,16 +339,6 @@ struct binary_format_traits<fixed_string_equal_2> {
   static constexpr const char op_string[] = "==";
 };
 
-template <>
-struct binary_format_traits<fixed_string_sstream_equal> {
-  static constexpr const char op_string[] = "==";
-};
-
-template <>
-struct binary_format_traits<fixed_string_format_eq_1> {
-  static constexpr const char op_string[] = "==";
-};
-
 }  // namespace testing
 }  // namespace oa
 

--- a/src/unit_test/fixed_string_test.cpp
+++ b/src/unit_test/fixed_string_test.cpp
@@ -167,7 +167,7 @@ struct fixed_string_sstream_equal {
    * @param s2 Second fixed string
    */
   template <std::size_t N1, std::size_t N2>
-  bool operator()(
+  auto operator()(
     const oa::fixed_string<N1>& s1,
     const oa::fixed_string<N2>& s2) const
   {
@@ -177,7 +177,7 @@ struct fixed_string_sstream_equal {
     std::stringstream ss2;
     ss2 << s2;
     // compare using operator== for std::string
-    return std::move(ss1).str() == std::move(ss2).str();
+    return oa::testing::eq(std::move(ss1).str(), std::move(ss2).str());
   }
 };
 
@@ -200,11 +200,11 @@ struct fixed_string_strcat_eq_1 {
    * @param s2 Second fixed string
    */
   template <std::size_t N1, std::size_t N2>
-  bool operator()(
+  auto operator()(
     const oa::fixed_string<N1>& s1,
     const oa::fixed_string<N2>& s2) const
   {
-    return (s1 + s2) == (std::string{s1} + s2);
+    return oa::testing::eq(s1 + s2, std::string{s1} + s2);
   }
 };
 
@@ -227,11 +227,11 @@ struct fixed_string_strcat_eq_2 {
    * @param s2 Second fixed string
    */
   template <std::size_t N1, std::size_t N2>
-  bool operator()(
+  auto operator()(
     const oa::fixed_string<N1>& s1,
     const oa::fixed_string<N2>& s2) const
   {
-    return (s1 + s2) == (s1 + std::string{s2});
+    return oa::testing::eq(s1 + s2, s1 + std::string{s2});
   }
 };
 
@@ -256,7 +256,7 @@ struct fixed_string_format_eq_1 {
     const oa::fixed_string<N2>& s2) const
   {
 #if OA_HAS_CXX20_FORMAT
-    return std::format("{}", s1) == std::string{s2};
+    return oa::testing::eq(std::format("{}", s1), std::string{s2});
 #else
     return ::testing::AssertionFailure() << "std::format() not available";
 #endif  // !OA_HAS_CXX20_FORMAT
@@ -268,7 +268,7 @@ struct fixed_string_format_eq_1 {
  */
 struct fixed_string_format_eq_2 {
   /**
-   * Compare the `std::format()` result against `std::string`.
+   * Compare the `std::format()` result against a given string.
    *
    * The format string is `"the world is your {:}"`.
    *
@@ -284,7 +284,7 @@ struct fixed_string_format_eq_2 {
     const oa::fixed_string<N2>& s2) const
   {
 #if OA_HAS_CXX20_FORMAT
-    return std::format("the world is your {:}", s1) == std::string{s2};
+    return oa::testing::eq(std::format("the world is your {:}", s1), s2);
 #else
     return ::testing::AssertionFailure() << "std::format() not available";
 #endif  // !OA_HAS_CXX20_FORMAT
@@ -312,7 +312,8 @@ struct fixed_string_format_eq_3 {
     const oa::fixed_string<N2>& s2) const
   {
 #if OA_HAS_CXX20_FORMAT
-    return std::format("we are moving the {:#} somewhere", s1) == std::string{s2};
+    using oa::testing::eq;
+    return eq(std::format("we are moving the {:#} somewhere", s1), s2);
 #else
     return ::testing::AssertionFailure() << "std::format() not available";
 #endif  // !OA_HAS_CXX20_FORMAT

--- a/src/unit_test/fixed_string_test.cpp
+++ b/src/unit_test/fixed_string_test.cpp
@@ -7,7 +7,13 @@
 
 #include "oa/fixed_string.h"
 
+// note: can include first as header only defines macros
+#include "oa/features.h"
+
 #include <cstddef>
+#if OA_HAS_CXX20_FORMAT
+#include <format>
+#endif  // OA_HAS_CXX20_FORMAT
 #include <sstream>
 #include <tuple>
 #include <type_traits>
@@ -15,6 +21,7 @@
 
 #include <gtest/gtest.h>
 
+#include "oa/ctti.h"
 #include "oa/testing/gtest.h"
 
 namespace {
@@ -228,6 +235,94 @@ struct fixed_string_strcat_eq_2 {
   }
 };
 
+/**
+ * `fixed_string` `std::format()` equality testing operator.
+ */
+struct fixed_string_format_eq_1 {
+  /**
+   * Compare the `std::format()` result against `std::string`.
+   *
+   * The format string is `"{}".`
+   *
+   * @tparam N1 Length of first string
+   * @tparam N2 Length of second string
+   *
+   * @param s1 First fixed string
+   * @param s2 Second fixed string
+   */
+  template <std::size_t N1, std::size_t N2>
+  auto operator()(
+    const oa::fixed_string<N1>& s1,
+    const oa::fixed_string<N2>& s2) const
+  {
+#if OA_HAS_CXX20_FORMAT
+    return std::format("{}", s1) == std::string{s2};
+#else
+    return ::testing::AssertionFailure() << "std::format() not available";
+#endif  // !OA_HAS_CXX20_FORMAT
+  }
+};
+
+/**
+ * `fixed_string` `std::format()` equality test.
+ */
+struct fixed_string_format_eq_2 {
+  /**
+   * Compare the `std::format()` result against `std::string`.
+   *
+   * The format string is `"the world is your {:}"`.
+   *
+   * @tparam N1 Length of first string
+   * @tparam N2 Length of second string
+   *
+   * @param s1 First fixed string
+   * @param s2 Second fixed string
+   */
+  template <std::size_t N1, std::size_t N2>
+  auto operator()(
+  const oa::fixed_string<N1>& s1,
+  const oa::fixed_string<N2>& s2) const
+  {
+#if OA_HAS_CXX20_FORMAT
+    return std::format("the world is your {:}", s1) == std::string{s2};
+#else
+    return ::testing::AssertionFailure() << "std::format() not available";
+#endif  // !OA_HAS_CXX20_FORMAT
+  }
+};
+
+/**
+ * `fixed_string` `std::format()` equality test.
+ */
+struct fixed_string_format_eq_3 {
+  /**
+   * Compare the `std::format()` result against `std::string`.
+   *
+   * The format string is `"we are moving the {:#} somewhere"`.
+   *
+   * @tparam N1 Length of first string
+   * @tparam N2 Length of second string
+   *
+   * @param s1 First fixed string
+   * @param s2 Second fixed string
+   */
+  template <std::size_t N1, std::size_t N2>
+  auto operator()(
+  const oa::fixed_string<N1>& s1,
+  const oa::fixed_string<N2>& s2) const
+  {
+#if OA_HAS_CXX20_FORMAT
+    return std::format("we are moving the {:#} somewhere", s1) == std::string{s2};
+#else
+    return ::testing::AssertionFailure() << "std::format() not available";
+#endif  // !OA_HAS_CXX20_FORMAT
+  }
+};
+
+/**
+ * `fixed_string `std::format("{:#}")
+ */
+
 }  // namespace
 
 // binary_format_traits specializations for fixed_string_equal_(1|2)
@@ -289,7 +384,7 @@ constexpr auto fixed_string_test_cases = std::make_tuple(
   fixed_string_binary_test_case{fixed_string_equal_1{}, "hello", "hello"},
   // 7. test fixed_string and char[] operator==
   fixed_string_binary_test_case{fixed_string_equal_2{}, "world", "world"},
-  // 8. test comparison after string conversion
+  // 8. test comparison after string conversion (runtime)
   fixed_string_binary_test_case{fixed_string_sstream_equal{}, "jello", "jello"},
   // 9. test char[] and fixed_string operator== (runtime)
   fixed_string_binary_test_case{fixed_string_equal_1{}, "burger", "burger"},
@@ -316,11 +411,35 @@ constexpr auto fixed_string_test_cases = std::make_tuple(
   // 14. test operator+, operator== for fixed_string + std::string (runtime)
   fixed_string_binary_test_case{fixed_string_strcat_eq_1{}, "hello ", "world"},
   // 15. test operator+, operator== for fixed_string + std::string (runtime)
-  fixed_string_binary_test_case{fixed_string_strcat_eq_2{}, "hello ", "world"}
+  fixed_string_binary_test_case{fixed_string_strcat_eq_2{}, "hello ", "world"},
+  // 16. test fixed_string with std::format (runtime)
+  fixed_string_binary_test_case{fixed_string_format_eq_1{}, "hello", "hello"},
+  // 17. test fixed_string with std::format (runtime)
+  fixed_string_binary_test_case{
+    fixed_string_format_eq_2{},
+    "oyster",
+    "the world is your oyster"
+  },
+  // 18. test fixed_string with std::format (runtime)
+  fixed_string_binary_test_case{
+    fixed_string_format_eq_3{},
+    "package",
+    "we are moving the \"package\" somewhere"
+  }
 );
 
 // indices of tests that should be evaluated at runtime
-constexpr const std::size_t fixed_string_runtime_test_cases[] = {7, 8, 9, 13, 14};
+constexpr const std::size_t fixed_string_runtime_test_cases[] = {
+  7, 8, 9, 13, 14, 15, 16, 17
+};
+
+// indices of tests that should be skipped
+// note: we can't have arrays of size 0 but index_sequence can have empty pack
+using fixed_string_skipped_test_cases = std::index_sequence<
+#if !OA_HAS_CXX20_FORMAT
+  15, 16, 17
+#endif  // OA_HAS_CXX20_FORMAT
+>;
 
 /**
  * `fixed_string` template test fixture.
@@ -345,7 +464,7 @@ private:
   /**
    * Indicate if the specified test case should be evaluated at compile-time.
    *
-   * @tparam I Index of test case in `fixed_string_test_cases`
+   * @tparam I Index of test case in `fixed_string_runtime_test_cases`
    */
   template <std::size_t I>
   static constexpr bool is_compile_time(std::index_sequence<I>) noexcept
@@ -354,6 +473,21 @@ private:
       if (I == fixed_string_runtime_test_cases[i])
         return false;
     return true;
+  }
+
+  /**
+   * Indicate if the specified test case should be skipped.
+   *
+   * @tparam I Index of test case in `fixed_string_skipped_test_cases`
+   * @tparam Is Indices in `fixed_string_skipped_test_cases`
+   */
+  template <std::size_t I, std::size_t... Is>
+  static constexpr bool is_skipped_test(
+    std::index_sequence<I>,
+    std::index_sequence<Is...>) noexcept
+  {
+    // note: could short-circuit but would be more verbose
+    return ((I == Is) || ...);
   }
 
 public:
@@ -373,6 +507,14 @@ public:
     return is_compile_time(T{});
   }
 
+  /**
+   * Indicate if the specified test case should be skipped.
+   */
+  static constexpr bool is_skipped_test() noexcept
+  {
+    return is_skipped_test(T{}, fixed_string_skipped_test_cases{});
+  }
+
 protected:
   /**
    * Perform test and report assertion results.
@@ -386,8 +528,11 @@ protected:
     constexpr auto& op = input().op();
     constexpr auto& s1 = input().s1();
     constexpr auto& s2 = input().s2();
-    // if compile-time test
-    if constexpr (is_compile_time())
+    // skipped test
+    if constexpr (is_skipped_test())
+      GTEST_SKIP() << OA_PRETTY_FUNCTION_NAME << ": test skipped";
+    // compile-time test
+    else if constexpr (is_compile_time())
       EXPECT_TRUE(oa::testing::make_result<op(s1, s2)>(op, s1, s2));
     // run-time test
     else

--- a/src/unit_test/fixed_string_test.cpp
+++ b/src/unit_test/fixed_string_test.cpp
@@ -280,8 +280,8 @@ struct fixed_string_format_eq_2 {
    */
   template <std::size_t N1, std::size_t N2>
   auto operator()(
-  const oa::fixed_string<N1>& s1,
-  const oa::fixed_string<N2>& s2) const
+    const oa::fixed_string<N1>& s1,
+    const oa::fixed_string<N2>& s2) const
   {
 #if OA_HAS_CXX20_FORMAT
     return std::format("the world is your {:}", s1) == std::string{s2};
@@ -308,8 +308,8 @@ struct fixed_string_format_eq_3 {
    */
   template <std::size_t N1, std::size_t N2>
   auto operator()(
-  const oa::fixed_string<N1>& s1,
-  const oa::fixed_string<N2>& s2) const
+    const oa::fixed_string<N1>& s1,
+    const oa::fixed_string<N2>& s2) const
   {
 #if OA_HAS_CXX20_FORMAT
     return std::format("we are moving the {:#} somewhere", s1) == std::string{s2};

--- a/src/unit_test/fixed_string_test.cpp
+++ b/src/unit_test/fixed_string_test.cpp
@@ -319,15 +319,14 @@ struct fixed_string_format_eq_3 {
   }
 };
 
-/**
- * `fixed_string `std::format("{:#}")
- */
-
 }  // namespace
 
-// binary_format_traits specializations for fixed_string_equal_(1|2)
 namespace oa {
 namespace testing {
+
+// binary_format_traits specializations for test case comparator types
+// note: not all the types are covered because some of them do transformations
+// on the input values so s1 op s2 won't represent the actual operation done
 
 template <>
 struct binary_format_traits<fixed_string_equal_1> {
@@ -336,6 +335,16 @@ struct binary_format_traits<fixed_string_equal_1> {
 
 template <>
 struct binary_format_traits<fixed_string_equal_2> {
+  static constexpr const char op_string[] = "==";
+};
+
+template <>
+struct binary_format_traits<fixed_string_sstream_equal> {
+  static constexpr const char op_string[] = "==";
+};
+
+template <>
+struct binary_format_traits<fixed_string_format_eq_1> {
   static constexpr const char op_string[] = "==";
 };
 


### PR DESCRIPTION
## Summary

Adds a `std::formatter` specialization for the `fixed_string<N>` and deals with some MSVC issues wrt `inititalizer_list`.

Originally, some fixes for MSVC were done because using `{cs...}` on a pack of chars `cs` as a range-for initializer caused issues with MSVC, as the initializer list ended up being deallocated too early at compile time. The workaround is just to initialize a `const char[]` with the pack. However, to enable use of `OA_SOURCE_LOCATION()` with `std::format`, we also need a `std::formatter`, so the changes were added to with a simple `std::formatter` implementation.

Tests for `std::format()` on `fixed_string` are added with some skip infrastructure due to GCC 11 not having `<format>`. Some additional GoogleTest helpers were added, in particular `oa::testing::eq()` and an improvement to `oa::test::make_result(...)`. Respectively, these improvements enable simpler `AssertionResult` creation + use of comparators that return an `AssertionResult` instead of just a `bool` or bool-convertible type.