### PR TITLE
add XLCALL32.DLL stub to satisfy runtime dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,28 @@
 cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
 
+# xlcall32_stub: a stub implementation of the real Excel XLCALL32 DLL
+#
+# this is provided so that any targets that link against the XLL SDK directly
+# or indirectly can correctly load at runtime. furthermore, any XLCALL32.DLL
+# exported functions called during runtime will complete but simply return an
+# error or failure value like xlRetFailed.
+#
+# see xlcall32_stub.cpp for more details on how the stub should be used.
+#
+if(XLLSDK_FOUND)
+    add_library(xlcall32_stub MODULE xlcall32_stub.cpp xlcall32_stub.def)
+    target_link_libraries(xlcall32_stub PRIVATE XLLSDK::SDK)
+    # make output name the same as the "real" XLCALL32.DLL
+    set_target_properties(
+        xlcall32_stub PROPERTIES
+        OUTPUT_NAME "XLCALL32"
+        SUFFIX ".DLL"
+        PDB_NAME "XLCALL32"
+    )
+else()
+    message(STATUS "Skipping xlcall32_stub (requires XLL SDK)")
+endif()
+
 # add library targets
 add_subdirectory(config)
 add_subdirectory(dao)

--- a/src/unit_test/CMakeLists.txt
+++ b/src/unit_test/CMakeLists.txt
@@ -41,6 +41,10 @@ if(TARGET oxl_api)
         oxl/xl_dictionary_test.cpp
     )
 endif()
+# add xlcall32_stub tests if xlcall32_stub is available
+if(TARGET xlcall32_stub)
+    target_sources(oa_unit_test PRIVATE xlcall32_stub_test.cpp)
+endif()
 # MSVC emits C5264 a lot for Google Test fixtures
 if(MSVC)
     target_compile_options(oa_unit_test PRIVATE /wd5264)
@@ -62,6 +66,12 @@ target_link_libraries(
 # link against oxl_api as necessary
 if(TARGET oxl_api)
     target_link_libraries(oa_unit_test PRIVATE oxl_api)
+endif()
+# link against XLL SDK for xlcall32_stub tests as they include XLCALL.H
+# note: Excel12[v]() symbol references typically would have been provided by
+# oxl_api since it links against XLLSDK::Framework which compiles XLCALL.CPP
+if(TARGET xlcall32_stub)
+    target_link_libraries(oa_unit_test PRIVATE XLLSDK::SDK12)
 endif()
 # ensure before oa_unit_test is built that static data is correctly copied.
 # although we could have hung this as a post-build command, this more correctly

--- a/src/unit_test/CMakeLists.txt
+++ b/src/unit_test/CMakeLists.txt
@@ -68,6 +68,21 @@ endif()
 # chains the dependency of oa_unit_test on the static data being located in the
 # same directory as the project artifacts (for local builds)
 add_dependencies(oa_unit_test oa_copy_static_data)
+#
+# if linking against oxl_api, which indirectly links against XLCALL32.LIB and
+# therefore will require XLCALL32.DLL to be available at runtime, we must have
+# the XLCALL32.DLL stub built before oa_unit_test. otherwise, oa_unit_test will
+# not load correctly when gtest_discover_tests() is called and break the build.
+#
+# note:
+#
+# this issue was *not* caught on CI because currently we don't make any calls
+# to XLCALL32.DLL exported functions so the linker likely just stripped out the
+# unused function references as part of its optimization pass.
+#
+if(TARGET oxl_api)
+    add_dependencies(oa_unit_test xlcall32_stub)
+endif()
 
 # enable defining OA_UNITY_ID for each agglomerated TU during unity builds
 # note: disabled for now as it is unused

--- a/src/unit_test/xlcall32_stub_test.cpp
+++ b/src/unit_test/xlcall32_stub_test.cpp
@@ -1,0 +1,162 @@
+/**
+ * @file xlcall32_stub_test.cpp
+ * @author Derek Huang
+ * @brief C++ unit tests for the stub `XLCALL32` DLL
+ * @copyright MIT License
+ */
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif  // WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <XLCALL.H>
+
+#include <system_error>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+/**
+ * Helper macro to get a `XLCALL32` proc address + check if it is not `NULL`.
+ *
+ * This can only be used from within the `StubXlCall32Test`.
+ *
+ * @param out Name to bind new function pointer to
+ * @param name Procedure name
+ * @param type Function type to cast `FARPROC` to
+ */
+#define GTEST_ASSERT_PROC_EXISTS(out, name, type) \
+  auto out = [&] { return reinterpret_cast<type>(xlcall32_proc(#name)); }(); \
+  ASSERT_TRUE(out) << #name "() missing: " << \
+    std::system_category().message(static_cast<int>(GetLastError()))
+
+/**
+ * Test fixture for stub `XLCALL32` DLL tests.
+ */
+class StubXlCall32Test : public ::testing::Test {
+protected:
+  /**
+   * Obtain the module handle for `XLCALL32`.
+   *
+   * This should not return `nullptr` and is required by most of the tests.
+   *
+   * @note The returned `HMODULE` does not increment the module ref count.
+   */
+  static auto xlcall32_handle()
+  {
+    auto hnd = GetModuleHandleA("XLCALL32");
+    if (!hnd)
+      throw std::system_error{
+        {static_cast<int>(GetLastError()), std::system_category()},
+        "GetModuleHandleA() failed"
+      };
+    return hnd;
+  }
+
+  /**
+   * Obtain the function pointer for the specified function.
+   *
+   * @param name Name of the DLL procedure to get a pointer to
+   */
+  static auto xlcall32_proc(const char* name)
+  {
+    return GetProcAddress(xlcall32_handle(), name);
+  }
+};
+
+/**
+ * Test that `Excel4()` is available and returns `xlretFailed`.
+ */
+TEST_F(StubXlCall32Test, Excel4Test)
+{
+  GTEST_ASSERT_PROC_EXISTS(
+    proc,
+    Excel4,
+    int (__cdecl *)(int, LPXLOPER, int, ...)
+  );
+  // both function pointer + name should work
+  XLOPER res;
+  EXPECT_EQ(xlretFailed, proc(xlSheetId, &res, 1, nullptr));
+  EXPECT_EQ(xlretFailed, Excel4(xlSheetId, &res, 1, nullptr));
+}
+
+/**
+ * Test that `Excel4v()` is available and returns `xlretFailed`.
+ */
+TEST_F(StubXlCall32Test, Excel4vTest)
+{
+  GTEST_ASSERT_PROC_EXISTS(
+    proc,
+    Excel4v,
+    int (pascal *)(int, LPXLOPER, int, LPXLOPER[])
+  );
+  // both function pointer + name should work
+  XLOPER res;
+  LPXLOPER args[] = {nullptr};
+  EXPECT_EQ(xlretFailed, proc(xlSheetId, &res, 1, args));
+  EXPECT_EQ(xlretFailed, Excel4v(xlSheetId, &res, 1, args));
+}
+
+/**
+ * Test that `LPenHelper()` is available and returns zero.
+ */
+TEST_F(StubXlCall32Test, LPenHelperTest)
+{
+  GTEST_ASSERT_PROC_EXISTS(proc, LPenHelper, long (pascal *)(int, VOID*));
+  // both function pointer + name should work
+  EXPECT_EQ(0, proc(xlGetFmlaInfo, nullptr));
+  EXPECT_EQ(0, LPenHelper(xlGetFmlaInfo, nullptr));
+}
+
+/**
+ * Test that `XLCallVer()` is available and returns zero.
+ */
+TEST_F(StubXlCall32Test, XLCallVerTest)
+{
+  GTEST_ASSERT_PROC_EXISTS(proc, XLCallVer, int (pascal *)());
+  // both function pointer + name should work
+  EXPECT_EQ(0, proc());
+  EXPECT_EQ(0, XLCallVer());
+}
+
+/**
+ * Test that `xlcall32_is_stub()` is available and returns `true`.
+ *
+ * This is the true way to distinguish if the loaded `XLCALL32.DLL` is our stub
+ * implementation or not as the real `XLCALL32.DLL` doesn't export this.
+ */
+TEST_F(StubXlCall32Test, StubProcTest)
+{
+  GTEST_ASSERT_PROC_EXISTS(proc, xlcall32_is_stub, bool (*)() noexcept);
+  ASSERT_TRUE(proc()) << "xlcall32_is_stub() should return true";
+}
+
+/**
+ * Test that `Excel12()` returns zero.
+ *
+ * Although not implemented by the stub `XLCALL32` DLL as it is implemented in
+ * `XLCALL.CPP`, if not running in Excel, `xlretFailed` should be returned.
+ */
+TEST_F(StubXlCall32Test, Excel12Test)
+{
+  XLOPER12 res;
+  EXPECT_EQ(xlretFailed, Excel12(xlSheetId, &res, 1, nullptr));
+}
+
+/**
+ * Test that `Excel12v()` returns zero
+ *
+ * This should also return `xlretFailed` like `Excel12()`.
+ */
+TEST_F(StubXlCall32Test, Excel12vTest)
+{
+  XLOPER12 res;
+  LPXLOPER12 args[] = {nullptr};
+  EXPECT_EQ(xlretFailed, Excel12v(xlSheetId, &res, 1, args));
+}
+
+// clean up (especially since we do unity builds)
+#undef GTEST_ASSERT_PROC_EXISTS
+
+}  // namespace

--- a/src/xlcall32_stub.cpp
+++ b/src/xlcall32_stub.cpp
@@ -1,0 +1,100 @@
+/**
+ * @file xlcall32_stub.cpp
+ * @author Derek Huang
+ * @brief C++ XLCALL32.DLL stub implementtation
+ * @copyright MIT License
+ *
+ * This file is designed to mock out the functions exported by `XLCALL32.DLL`:
+ *
+ * @code
+ * File Type: DLL
+ *
+ * Section contains the following exports for XLCall32.dll
+ *
+ *     00000000 characteristics
+ *     69167869 time date stamp Thu Nov 13 19:31:37 2025
+ *         0.00 version
+ *            1 ordinal base
+ *            4 number of functions
+ *            4 number of names
+ *
+ *     ordinal hint RVA      name
+ *
+ *           2    0 00001080 Excel4
+ *           3    1 000011B0 Excel4v
+ *           4    2 00001220 LPenHelper
+ *           1    3 00001070 XLCallVer
+ * @endcode
+ *
+ * This enables us to run applications that link against `XLCALL32.LIB` without
+ * requiring locating a true Excel installation's `XLCALL32.DLL` for testing.
+ *
+ * To distinguish this from a "real" Excel `XLCALL32.DLL` at runtime one can
+ * either check if `GetProcAddress(h, "xlcall32_is_stub")` is not `NULL`, where
+ * `h` is the `GetModuleHandleA("XLCALL32")` handle, or from code that includes
+ * `XLCALL.H`, call `XLCallVer()` and check if the return value is zero.
+ *
+ * The benefit of adding the `xlcall32_is_stub()` function is primarily to make
+ * it easy to determine that an `XLCALL32.DLL` is this stub implementation via
+ * usage of `dumpbin /exports XLCALL32.DLL`.
+ *
+ * @note This file must be compiled with the provided `.def` file and linked
+ *  into a DLL called `XLCALL32.DLL`. We cannot `__declspec(dllexport)` because
+ *  MSVC will complain about a change in linkage and because the `.def` file
+ *  is the only way we can export names at specific ordinals.
+ *
+ * @todo Mock implementations may be provided to simulate callback
+ *  functionality, e.g. so `xlFree` and `xlGetName` can work.
+ */
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif  // WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <XLCALL.H>
+
+extern "C" {
+
+/**
+ * `Excel4()` stub that always returns `xlretFailed`.
+ */
+int __cdecl Excel4(int, LPXLOPER, int, ...)
+{
+  return xlretFailed;
+}
+
+/**
+ * `Excel4v()` stub that always returns `xlretFailed`.
+ */
+int pascal Excel4v(int, LPXLOPER, int, LPXLOPER[])
+{
+  return xlretFailed;
+}
+
+/**
+ * `LPenHelper()` stub that always returns zero.
+ */
+long pascal LPenHelper(int, VOID*)
+{
+  return 0;
+}
+
+/**
+ * `XLCallVer()` stub that always returns zero.
+ */
+int pascal XLCallVer()
+{
+  return 0;
+}
+
+/**
+ * Return `true` to indicate this DLL is a `XLCALL32` stub implementation.
+ *
+ * @note We can use `__declspec(dllexport)` here since this is our function.
+ */
+__declspec(dllexport) bool xlcall32_is_stub() noexcept
+{
+  return true;
+}
+
+}  // extern "C"

--- a/src/xlcall32_stub.def
+++ b/src/xlcall32_stub.def
@@ -1,0 +1,6 @@
+LIBRARY     XLCALL32
+EXPORTS
+    Excel4      @2
+    Excel4v     @3
+    LPenHelper  @4
+    XLCallVer   @1


### PR DESCRIPTION
## Summary

Add an `XLCALL32.DLL` like in #86 to satisfy `oa_unit_test` linker requirements.

When #93 and #95 were merged new unit tests were added for `XlArray` and `XlDictionary` which require linking in the objects of the `oxl_api` static library (from #90). The issue here is that due to `oxl_api` symbols being used (not just the types for some traits testing like in `handle_prefixer_test.cpp`), the implicit dependency on `XLCALL32.DLL` exported symbols (likely from `xloper_converter.cpp`) is brought into `oa_unit_test`, and therefore `XLCALL32.DLL`, the DLL provided by an Excel installation that supports XLL add-in functionality, becomes a load-time DLL requirement.

For proof, here is the `dumpbin` + `find` output with the Debug config `oa_unit_test.exe` from [current HEAD](https://github.com/Mjang714/OdinAnalytics/commit/cbdbc9df38d3513d5310e93bdc6ae26d0d42da34):

```
> dumpbin /dependents .\build_windows_x64\Debug\oa_unit_test.exe | find /i "XLCALL32.DLL"
    XLCall32.dll
```

This was an issue that was known in #86 where Accel SDK tests were added to `oa_unit_test` and there was the issue of `XLCALL32.DLL` not being available at runtime for `oa_unit_test`. Although one approach is to write some CMake code to look for an Excel installation and then ensure that the directory containing `EXCEL.EXE` and `XLCALL32.DLL` is part of the `PATH` that `oa_unit_test` is invoked under by CTest, this is kind of complicated, and won't work on CI (no Excel).

It turns out to be *much* easier to just mock `XLCALL32.DLL`, since without an instance of Excel running, all Excel SDK calls are ill-formed anyways. Therefore, this PR provides a mocked-out `XLCALL32.DLL` stub that can be used to satisfy the runtime load requirements of `oa_unit_test.exe` during build + testing that is also easily distinguishable from the "real" `XLCALL32.DLL` as the stub contains the `xlcall32_is_stub()` exported function to indicate its status as a stub implementation.

> [!NOTE]
>
> There is *no* impact to loading XLLs for testing with Excel, as when Excel loads the XLL, it looks in its *own* directory to resolve the runtime `XLCALL32.DLL` requirement, *not* in the directory the XLL resides in.

> [!NOTE]
>
> The reason this DLL load issue is *not* caught by our CI is because the GitHub Actions builds run only the *Release* build config. Compiler optimization likely removed the dead (unused) `XLCALL32.DLL` references and so the Release config `oa_unit_test.exe` doesn't have `XLCALL32.DLL` as a load-time DLL requirement:
>
> ```
> > dumpbin /dependents build_windows_x64\Release\oa_unit_test.exe | find /i "XLCALL32.DLL"
> ```
>
> There is no shell output so there is no `XLCALL32.DLL` required at load-time by the Release config `oa_unit_test.exe`.