### PR TITLE
enhance Tenor operators + STL container interop

### DIFF
--- a/src/time/tenor.cpp
+++ b/src/time/tenor.cpp
@@ -58,8 +58,8 @@ Tenor::Tenor(const std::string& input_string)
 		throw "Invalid tenor type please check your input of " + input_string;
 }
 
-Tenor::Tenor(int count, oa::time::Tenors unit) noexcept
-	: m_number_(count), m_time_unit_(unit)
+Tenor::Tenor(int count, Tenors unit) noexcept
+  : m_number_{count}, m_time_unit_{unit}
 {}
 
 Tenor Tenor::FlipSign() const
@@ -68,9 +68,9 @@ Tenor Tenor::FlipSign() const
 	return {-count(), unit()};
 }
 
-std::pair<int, oa::time::Tenors>Tenor::GetValues() const
+std::pair<int, Tenors>Tenor::GetValues() const
 {
-	return std::pair<int, oa::time::Tenors>(m_number_, m_time_unit_);
+	return {m_number_, m_time_unit_};
 }
 
 int

--- a/src/time/tenor.cpp
+++ b/src/time/tenor.cpp
@@ -1,45 +1,166 @@
 #include "tenor.h"
 
-#include <boost/algorithm/string.hpp>
+#include <cctype>
+#include <cstddef>
+#include <ostream>
+#include <string>
 
 #include "helpers/utils.h"
 
-namespace oa
+namespace oa {
+namespace time {
+
+////////////////////////////////////////////////////////////////////////////////
+// Tenor::GroupLess                                                           //
+////////////////////////////////////////////////////////////////////////////////
+
+bool
+Tenor::GroupLess::operator()(const Tenor& a, const Tenor& b) const noexcept
 {
-	namespace time
+	// convert enum to ranking
+	// TODO: can have this as a free function later
+	auto rank = [](Tenors u) noexcept
 	{
-		Tenor::Tenor(const std::string& input_string)
-		{
-			try
-			{
-				if (oa::utils::CheckTenorStr(input_string))
-				{
-					m_number_ = std::stoi(input_string.substr(0, input_string.size() - 1));
-					m_time_unit_ = oa::utils::ValueToEnum<time::Tenors>(toupper(input_string.back()));
-				}
-				else
-				{
-					throw "Invalid tenor type please check your input of " + input_string;
-				}
-			}
-			catch (const std::exception&) {}
+		switch (u) {
+		case Tenors::kDays:
+			return 0u;
+		case Tenors::kWeeks:
+			return 1u;
+		case Tenors::kMonths:
+			return 2u;
+		case Tenors::kYears:
+			return 3u;
+		// bogus ranking value to ensure bad values are ordered last
+		default:
+			return 100u;
 		}
+	};
+	// get a and b rank
+	auto a_rank = rank(a.unit());
+	auto b_rank = rank(b.unit());
+	// if rank is the same, compare counts, otherwise compare ranks
+	return (a_rank == b_rank) ? (a.count() < b.count()) : (a_rank < b_rank);
+}
 
+////////////////////////////////////////////////////////////////////////////////
+// Tenor                                                                      //
+////////////////////////////////////////////////////////////////////////////////
 
-		Tenor::Tenor(int time_length, oa::time::Tenors tenor_enum) : m_number_(time_length), m_time_unit_(tenor_enum)
-		{
+// TODO: clean this function up later
+Tenor::Tenor(const std::string& input_string)
+{
+	if (oa::utils::CheckTenorStr(input_string))
+	{
+		m_number_ = std::stoi(input_string.substr(0, input_string.size() - 1));
+		m_time_unit_ = oa::utils::ValueToEnum<time::Tenors>(std::toupper(input_string.back()));
+	}
+	else
+		throw "Invalid tenor type please check your input of " + input_string;
+}
 
-		}
+Tenor::Tenor(int count, oa::time::Tenors unit) noexcept
+	: m_number_(count), m_time_unit_(unit)
+{}
 
-		const Tenor Tenor::FlipSign() const
-		{
-			return Tenor(std::to_string( -m_number_) +
-				static_cast<char> (m_time_unit_));
-		}
+Tenor Tenor::FlipSign() const
+{
+	// note: old implementation used the std::string ctor which is inefficient
+	return {-count(), unit()};
+}
 
-		const std::pair<int, oa::time::Tenors>Tenor::GetValues() const
-		{
-			return std::pair<int, oa::time::Tenors>(m_number_, m_time_unit_);
+std::pair<int, oa::time::Tenors>Tenor::GetValues() const
+{
+	return std::pair<int, oa::time::Tenors>(m_number_, m_time_unit_);
+}
+
+int
+Tenor::count() const noexcept
+{
+	return m_number_;
+}
+
+Tenors
+Tenor::unit() const noexcept
+{
+	return m_time_unit_;
+}
+
+Tenor
+Tenor::operator-() const noexcept
+{
+	return {-m_number_, m_time_unit_};
+}
+
+bool
+Tenor::operator==(const Tenor& other) const noexcept
+{
+	return (count() == other.count()) && (unit() == other.unit());
+}
+
+std::size_t
+Tenor::hash() const noexcept
+{
+	// FNV prime
+	constexpr auto prime = []() -> std::size_t
+	{
+		if constexpr (sizeof(std::size_t) == 4u)  // 32 bit
+			return 0x1000193;
+		else
+			return 0x100000001b3;                 // 64 bit
+	}();
+	// initial result (offset)
+	auto result = []() -> std::size_t
+	{
+		if constexpr (sizeof(std::size_t) == 4u)  // 32 bit
+			return 0x811c9dc5;
+		else
+			return 0xcbf29ce484222325;            // 64 bit
+	}();
+	// hash tenor count byte-by-byte
+	{
+		auto num = count();
+		// for each byte do multiply + XOR
+		for (auto i = 0u; i < sizeof(decltype(num)); i++) {
+			result *= prime;
+			result ^= (0xFF & num);
+			num >>= 8;
 		}
 	}
+	// tenor unit fits in one byte so only hash low byte
+	result *= prime;
+	result ^= (0xFF & static_cast<int>(unit()));
+	// done
+	return result;
 }
+
+Tenor
+Tenor::operator+(int shift) const noexcept
+{
+	return {count() + shift, unit()};
+}
+
+Tenor
+Tenor::operator-(int shift) const noexcept
+{
+	return {count() - shift, unit()};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tenor non-member operators                                                 //
+////////////////////////////////////////////////////////////////////////////////
+
+Tenor operator+(int shift, const Tenor& tenor) noexcept
+{
+	return tenor + shift;  // calls Tenor::operator+
+}
+
+std::ostream& operator<<(std::ostream& out, const Tenor& tenor)
+{
+	// convert enum value to lowercase (ASCII offset of 'a' - 'A' is 32)
+	auto unit = static_cast<char>(static_cast<int>(tenor.unit()) + 32);
+	// write
+	return out << tenor.count() << unit;
+}
+
+}  // namespace time
+}  // namespace oa

--- a/src/time/tenor.cpp
+++ b/src/time/tenor.cpp
@@ -125,12 +125,6 @@ Tenor::hash() const noexcept
 			result ^= (0xFF & num);
 			num >>= 8;
 		}
-
-		//that fact I need this function is really sign I messed up somewhere. Maybe we ca instead implement a hash function  using the string of the tenor?
-		bool Tenor::operator==(const Tenor& other) const
-		{
-			return this->m_number_ == other.m_number_ && this->m_time_unit_ == other.m_time_unit_;
-		}
 	}
 	// tenor unit fits in one byte so only hash low byte
 	result *= prime;

--- a/src/time/tenor.h
+++ b/src/time/tenor.h
@@ -1,38 +1,184 @@
-#ifndef OPENANALYTICS_TIME_TENOR_H
-#define OPENANALYTICS_TIME_TENOR_H
+#ifndef OA_TIME_TENOR_H_
+#define OA_TIME_TENOR_H_
 
+#include <cstddef>
+#include <iosfwd>
 #include <string>
 
 #include "oa/dllexport.h"
 #include "time_enums.h"
 
-//tc = tenor class
-namespace oa::time
-{
-	class OA_TIME_API Tenor
-	{
-		public:
-			Tenor(const std::string& input_string);
+namespace oa::time {
 
-			Tenor(int time_length, oa::time::Tenors tenor_enum);
-			/// <summary>
-			/// flips the sign of the tenor
-			/// </summary>
-			/// <returns>New Tenor object withteh sign flipped</returns>
-			const Tenor FlipSign() const;
-
-			/// <summary>
-			/// returns a pair that is the integer and the unit of time a char
-			/// </summary>
-			/// <returns>a pair where the first length and the second argument is lenght as a Enum</returns>
-			const std::pair<int, oa::time::Tenors> GetValues() const;
-
-		private:
-			int m_number_ = 0;
-			oa::time::Tenors m_time_unit_{};
+class OA_TIME_API Tenor {
+public:
+	/**
+	 * `Tenor` comparison functor that groups relation by time unit.
+	 *
+	 * This provides a strict weak ordering of `Tenor` objects based on their
+	 * time unit and then provides a strict ordering within each time unit
+	 * category based on the unit count. For example, any `Tenor` that is in
+	 * days is automatically ordered before a `Tenor` in weeks, even if the
+	 * number of days exceeds 7, e.g. `12d` is ordered before `1w`. Another
+	 * example would be `24m` being ordered before `1y`.
+	 *
+	 * Although this property makes this *Compare* functor inappropriate for
+	 * imposing a total ordering in an arithmetic sense, grouping tenors by
+	 * unit provides an ordering familiar to traders, and allows use with
+	 * `std::map` so a `Tenor` can be used as a key.
+	 */
+	struct OA_TIME_API GroupLess {
+		/**
+		 * Indicate if one `Tenor` is ordered before the other.
+		 *
+		 * Ordering is strictly grouped based on the length of the time unit
+		 * while intra-group ordering is strict based on count.
+		 *
+		 * @param a First tenor
+		 * @param b Second tenor
+		 */
+		bool operator()(const Tenor& a, const Tenor& b) const noexcept;
 	};
-}
 
+	/**
+	 * Ctor.
+	 *
+	 * Construct from a valid tenor string like `"3w"`. The case of the given
+	 * time unit can be lower or upper case, i.e. `"3W"` is also allowed.
+	 *
+	 * @todo Should use `string_view` to avoid needing to create a string.
+	 *
+	 * @param str Tenor string, e.g. `"2y"` or `"2Y"`
+	 */
+	Tenor(const std::string& str);
 
+	/**
+	 * Ctor.
+	 *
+	 * Construct the tenor from a time unit and the number of time units.
+	 *
+	 * @param count Number of time units
+	 * @param unit Tenor time unit enum value
+	 */
+	Tenor(int count, Tenors unit) noexcept;
 
-#endif // !OPENANALYTICS_TIME_TENOR_H
+	// TODO: deprecate in factor of unary negation
+	/// <summary>
+	/// flips the sign of the tenor
+	/// </summary>
+	/// <returns>New Tenor object withteh sign flipped</returns>
+	Tenor FlipSign() const;
+
+	// TODO: deprecate in factor of just using count() and unit()
+	/// <summary>
+	/// returns a pair that is the integer and the unit of time a char
+	/// </summary>
+	/// <returns>a pair where the first length and the second argument is lenght as a Enum</returns>
+	std::pair<int, oa::time::Tenors> GetValues() const;
+
+	/**
+	 * Return the number of units represented by the tenor.
+	 */
+	int count() const noexcept;
+
+	/**
+	 * Return the time unit value.
+	 */
+	Tenors unit() const noexcept;
+
+	/**
+	 * Flip the sign of the tenor.
+	 *
+	 * This produces a new `Tenor` object of same unit with negated count.
+	 */
+	Tenor operator-() const noexcept;
+
+	/**
+	 * Compare against another tenor for equality.
+	 *
+	 * Tenor equality is done strictly in terms of the count + unit together.
+	 * Therefore, a tenor of 7d is *not* considered equal to 1w.
+	 *
+	 * @param other Tenor to compare against
+	 */
+	bool operator==(const Tenor& other) const noexcept;
+
+	/**
+	 * Return a hash value for the `Tenor`.
+	 *
+	 * The hash value is computed for 32- and 64-bit platforms using the
+	 * FNV-1 hash algorithm. In theory, however, if we restricted the value
+	 * of count to fit within 3 bytes, then we could use this implementation:
+	 *
+	 * @code{.cc}
+	 * (std::size_t{count() } << 8) | (0xFF & static_cast<int>(unit()))
+	 * @endcode
+	 *
+	 * This takes advantage of the fact that the values of the `Tenors` enum
+	 * all nicely fit within a single byte so we only need the low byte.
+	 */
+	std::size_t hash() const noexcept;
+
+	/**
+	 * Add the given count to create a new `Tenor` object.
+	 *
+	 * @param shift Unit quantity to add
+	 */
+	Tenor operator+(int shift) const noexcept;
+
+	/**
+	 * Subtract the given count to create a new `Tenor` object.
+	 *
+	 * @note There is no accompanying operator for `int` - `Tenor`.
+	 *
+	 * @param shift Unit quantity to subtract
+	 */
+	Tenor operator-(int shift) const noexcept;
+
+private:
+	// TODO: rename members so they are semantically consistent with getters
+	int m_number_;
+	Tenors m_time_unit_;
+};
+
+/**
+ * Add the given count to create a new `Tenor` object.
+ *
+ * @param shift Unit quantity to add
+ * @param tenor Tenor to adjust
+ */
+OA_TIME_API
+Tenor operator+(int shift, const Tenor& tenor) noexcept;
+
+/**
+ * Write the `Tenor` to the output stream.
+ *
+ * This will write the natural language form of a tenor, e.g. `"3m"`.
+ *
+ * @param out Output stream
+ * @param tenor Tenor to write
+ */
+OA_TIME_API
+std::ostream& operator<<(std::ostream& out, const Tenor& tenor);
+
+}  // namespace oa::time
+
+namespace std {
+
+/**
+ * `std::hash` specialization for the `Tenor`.
+ */
+template <>
+struct hash<oa::time::Tenor> {
+	/**
+	 * Return the value of `Tenor::hash()` on the given `Tenor`.
+	 */
+	auto operator()(const oa::time::Tenor& tenor) const noexcept
+	{
+		return tenor.hash();
+	}
+};
+
+}  // namespace std
+
+#endif  // OA_TIME_TENOR_H_

--- a/src/time/tenor.h
+++ b/src/time/tenor.h
@@ -62,14 +62,14 @@ public:
 	 */
 	Tenor(int count, Tenors unit) noexcept;
 
-	// TODO: deprecate in factor of unary negation
+	// TODO: deprecate in favor of unary negation
 	/// <summary>
 	/// flips the sign of the tenor
 	/// </summary>
 	/// <returns>New Tenor object withteh sign flipped</returns>
 	Tenor FlipSign() const;
 
-	// TODO: deprecate in factor of just using count() and unit()
+	// TODO: deprecate in favor of just using count() and unit()
 	/// <summary>
 	/// returns a pair that is the integer and the unit of time a char
 	/// </summary>
@@ -111,7 +111,7 @@ public:
 	 * of count to fit within 3 bytes, then we could use this implementation:
 	 *
 	 * @code{.cc}
-	 * (std::size_t{count() } << 8) | (0xFF & static_cast<int>(unit()))
+	 * (std::size_t{count()} << 8) | (0xFF & static_cast<int>(unit()))
 	 * @endcode
 	 *
 	 * This takes advantage of the fact that the values of the `Tenors` enum

--- a/src/time/tenor.h
+++ b/src/time/tenor.h
@@ -74,7 +74,7 @@ public:
 	/// returns a pair that is the integer and the unit of time a char
 	/// </summary>
 	/// <returns>a pair where the first length and the second argument is lenght as a Enum</returns>
-	std::pair<int, oa::time::Tenors> GetValues() const;
+	std::pair<int, Tenors> GetValues() const;
 
 	/**
 	 * Return the number of units represented by the tenor.

--- a/src/unit_test/tenor_test.cpp
+++ b/src/unit_test/tenor_test.cpp
@@ -1,60 +1,183 @@
-#include "gtest/gtest.h"
 #include "time/tenor.h"
-namespace 
+
+#include <cstddef>
+#include <set>
+#include <unordered_set>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "time/time_enums.h"
+
+namespace {
+
+/**
+ * Test fixture for the `Tenor` tests.
+ */
+class TenorTest : public ::testing::Test {
+protected:
+	// convenience alias for tests
+	using Tenor = oa::time::Tenor;
+	using Tenors = oa::time::Tenors;
+};
+
+TEST_F(TenorTest, ValidConstructors)
 {
-	TEST(TenorClassTest, ValidConstructors)
-	{
-		EXPECT_NO_THROW(oa::time::Tenor("100M"));
-		EXPECT_NO_THROW(oa::time::Tenor("100d"));
-		EXPECT_NO_THROW(oa::time::Tenor("12341234120Y"));
-		EXPECT_NO_THROW(oa::time::Tenor("100y"));
-	}
-
-	TEST(TenorClassTest, InvalidConstructors)
-	{
-		EXPECT_ANY_THROW(oa::time::Tenor("1OM"));
-		EXPECT_ANY_THROW(oa::time::Tenor("M10M"));
-		EXPECT_ANY_THROW(oa::time::Tenor("20983409M241092384901823M"));
-		EXPECT_ANY_THROW(oa::time::Tenor("1843209841903MM"));
-		EXPECT_ANY_THROW(oa::time::Tenor("M12341234M"));
-		EXPECT_ANY_THROW(oa::time::Tenor("12341234Y2310938490128y"));
-	}
-
-	TEST(TenorClassTest, TenorGetValues)
-	{
-		oa::time::Tenor tenor_1("100M");
-		auto first_values = tenor_1.GetValues();
-
-		EXPECT_EQ(100, first_values.first);
-		EXPECT_EQ(oa::time::Tenors::kMonths, first_values.second);
-
-		oa::time::Tenor tenor_2("5y");
-		auto second_values = tenor_2.GetValues();
-
-		EXPECT_EQ(5, second_values.first);
-		EXPECT_EQ(oa::time::Tenors::kYears, second_values.second);
-
-		oa::time::Tenor tenor_3("-10y");
-		auto third_values = tenor_3.GetValues();
-
-		EXPECT_EQ(-10, third_values.first);
-		EXPECT_EQ(oa::time::Tenors::kYears, third_values.second);
-
-	}
-
-	TEST(TenorClassTest, FlipSignFunc)
-	{
-		oa::time::Tenor tenor_1("5y");
-		oa::time::Tenor tenor_2 = tenor_1.FlipSign();
-		auto flipped_val_1 = tenor_2.GetValues();
-
-		EXPECT_EQ(-5, flipped_val_1.first);
-		EXPECT_EQ(oa::time::Tenors::kYears, flipped_val_1.second);
-
-		oa::time::Tenor tenor_3 = tenor_2.FlipSign();
-		auto flipped_val_2 = tenor_3.GetValues();
-
-		EXPECT_EQ(5, flipped_val_2.first);
-		EXPECT_EQ(oa::time::Tenors::kYears, flipped_val_2.second);
-	}
+	EXPECT_NO_THROW(oa::time::Tenor("100M"));
+	EXPECT_NO_THROW(oa::time::Tenor("100d"));
+	EXPECT_NO_THROW(oa::time::Tenor("1234123412Y"));
+	EXPECT_NO_THROW(oa::time::Tenor("100y"));
 }
+
+TEST_F(TenorTest, InvalidConstructors)
+{
+	EXPECT_ANY_THROW(oa::time::Tenor("1OM"));
+	EXPECT_ANY_THROW(oa::time::Tenor("M10M"));
+	EXPECT_ANY_THROW(oa::time::Tenor("20983409M241092384901823M"));
+	EXPECT_ANY_THROW(oa::time::Tenor("1843209841903MM"));
+	EXPECT_ANY_THROW(oa::time::Tenor("M12341234M"));
+	EXPECT_ANY_THROW(oa::time::Tenor("12341234Y2310938490128y"));
+}
+
+TEST_F(TenorTest, TenorGetValues)
+{
+	oa::time::Tenor tenor_1("100M");
+	auto first_values = tenor_1.GetValues();
+
+	EXPECT_EQ(100, first_values.first);
+	EXPECT_EQ(oa::time::Tenors::kMonths, first_values.second);
+
+	oa::time::Tenor tenor_2("5y");
+	auto second_values = tenor_2.GetValues();
+
+	EXPECT_EQ(5, second_values.first);
+	EXPECT_EQ(oa::time::Tenors::kYears, second_values.second);
+
+	oa::time::Tenor tenor_3("-10y");
+	auto third_values = tenor_3.GetValues();
+
+	EXPECT_EQ(-10, third_values.first);
+	EXPECT_EQ(oa::time::Tenors::kYears, third_values.second);
+
+}
+
+TEST_F(TenorTest, FlipSignFunc)
+{
+	oa::time::Tenor tenor_1("5y");
+	oa::time::Tenor tenor_2 = tenor_1.FlipSign();
+	auto flipped_val_1 = tenor_2.GetValues();
+
+	EXPECT_EQ(-5, flipped_val_1.first);
+	EXPECT_EQ(oa::time::Tenors::kYears, flipped_val_1.second);
+
+	oa::time::Tenor tenor_3 = tenor_2.FlipSign();
+	auto flipped_val_2 = tenor_3.GetValues();
+
+	EXPECT_EQ(5, flipped_val_2.first);
+	EXPECT_EQ(oa::time::Tenors::kYears, flipped_val_2.second);
+}
+
+/**
+ * Test that negating the count of a `Tenor` works as expected.
+ */
+TEST_F(TenorTest, NegationTest)
+{
+	Tenor t1{5, Tenors::kMonths};
+	Tenor t2{-t1.count(), t1.unit()};
+	EXPECT_EQ(t2, -t1);
+}
+
+/**
+ * Test that adding an integer to a `Tenor` works as expected.
+ */
+TEST_F(TenorTest, LeftAddTest)
+{
+	Tenor t1{10, Tenors::kWeeks};
+	Tenor t2{16, t1.unit()};
+	EXPECT_EQ(t2, t1 + 6);
+}
+
+/**
+ * Test that adding a `Tenor` to an integer works as expected.
+ */
+TEST_F(TenorTest, RightAddTest)
+{
+	Tenor t1{5, Tenors::kYears};
+	Tenor t2{8, t1.unit()};
+	EXPECT_EQ(t2, 3 + t1);
+}
+
+/**
+ * Test that substracting an integer from a `Tenor` works as expected.
+ */
+TEST_F(TenorTest, SubtractTest)
+{
+	Tenor t1{3, Tenors::kMonths};
+	Tenor t2{1, t1.unit()};
+	EXPECT_EQ(t2, t1 - 2);
+}
+
+/**
+ * Test that `Tenor::GroupLess` works with `std::set` and orders correctly.
+ */
+TEST_F(TenorTest, GroupLessSetTest)
+{
+	// construct from initializer list
+	std::set<Tenor, Tenor::GroupLess> tenors{
+		{1, Tenors::kYears},
+		{2, Tenors::kMonths},
+		{3, Tenors::kWeeks},
+		{4, Tenors::kDays},
+		{1, Tenors::kDays},
+		{2, Tenors::kWeeks},
+		{3, Tenors::kMonths},
+		{4, Tenors::kYears}
+	};
+	// vector of tenors in the expected order
+	std::vector<Tenor> ref_tenors{
+		{1, Tenors::kDays},
+		{4, Tenors::kDays},
+		{2, Tenors::kWeeks},
+		{3, Tenors::kWeeks},
+		{2, Tenors::kMonths},
+		{3, Tenors::kMonths},
+		{1, Tenors::kYears},
+		{4, Tenors::kYears}
+	};
+	// compare
+	// note: GoogleMock is smart enough to compare STL containers of different
+	// type as long as the value_type type members are the same
+	EXPECT_THAT(tenors, ::testing::Pointwise(::testing::Eq(), ref_tenors));
+}
+
+/**
+ * Test that `std::hash<Tenor>` works with `std::unordered_set`.
+ */
+TEST_F(TenorTest, HashSetTest)
+{
+	// note: not in any particular order
+	std::unordered_set<Tenor> tenors{
+		{1, Tenors::kYears},
+		{2, Tenors::kMonths},
+		{3, Tenors::kWeeks},
+		{4, Tenors::kDays},
+		{1, Tenors::kDays},
+		{2, Tenors::kWeeks},
+		{3, Tenors::kMonths},
+		{4, Tenors::kYears}
+	};
+	// should see all elements in the set
+	EXPECT_EQ(8u, tenors.size());
+	// all hash values should be unique
+	// note: one might be tempted to check the buckets in the set to see if
+	// each bucket has <=1 element, but elements with different hashes can end
+	// up in the same bucket anyways. so it's an unhelpful check
+	std::unordered_set<std::size_t> hashes;
+	for (const auto& tenor : tenors)
+		hashes.insert(std::hash<Tenor>{}(tenor));
+	// should be exactly 8 different hash values
+	EXPECT_EQ(8u, hashes.size());
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Add some arithmetic operators and STL container integration for the `Tenor` besides some clean up.

Changes:

* Add `operator+` to allow increasing say `3m` to `7m` by adding 4 (symmetric operator)
* Add `operator-` to allow decreasing say `12y` to `5y` by subtracting 7 (not symmetric of course)
* Provide `Tenor::GroupLess` to provide a "natural" strict weak ordering for `std::map` grouped by tenor unit
* Make `FlipSign()` more efficient by not using string ctor + use same implementation for unary negation
* Add `count()` and `unit()` getters for the `Tenor`
* Add `operator==` for `Tenor`
* Add `Tenor::hash()` member function to implement `std::hash<Tenor>` by applying the [FNV-1 hash algorithm](https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV-1_hash)
* Add `operator<<` to enable streaming tenors in human-readable format, e.g. `"7y"`
* Add tests of all operators and interop with `std::set`, `std::unordered_set`