### PR TITLE
add constexpr locale-independent to_lower() and to_upper() + tests

### DIFF
--- a/include/oa/string.h
+++ b/include/oa/string.h
@@ -1,0 +1,41 @@
+/**
+ * @file string.h
+ * @author Derek Huang
+ * @brief C++ header for string helpers
+ * @copyright MIT License
+ */
+
+#ifndef OA_STRING_H_
+#define OA_STRING_H_
+
+namespace oa {
+
+/**
+ * Convert a character value to its ASCII uppercase equivalent.
+ *
+ * If the character value is not one of the ASCII lowercase values the input
+ * character is returned as-is independent of character encoding.
+ *
+ * @param c ASCII character to convert
+ */
+constexpr char to_upper(char c) noexcept
+{
+  return (c >= 'a' && c <= 'z') ? c - 'a' + 'A' : c;
+}
+
+/**
+ * Convert a character value to its ASCII lowercase equivalent.
+ *
+ * If the character value is not one of the ASCII uppercase values that input
+ * character is returned as-is independent of character encoding.
+ *
+ * @param c ASCII character to convert
+ */
+constexpr char to_lower(char c) noexcept
+{
+  return (c >= 'A' && c <= 'Z') ? c - 'A' + 'a' : c;
+}
+
+}  // namespace oa
+
+#endif  // OA_STRING_H_

--- a/src/unit_test/CMakeLists.txt
+++ b/src/unit_test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
     helpers/business_logic_check_test.cpp
     helpers/enum_test.cpp
     static_data_cache/static_data_cache_test.cpp
+    string_test.cpp
     tenor_test.cpp
     time/date_adjust/adjustment_factory_test.cpp
     time/date_adjust/date_adjust_following_test.cpp

--- a/src/unit_test/string_test.cpp
+++ b/src/unit_test/string_test.cpp
@@ -1,0 +1,188 @@
+/**
+ * @file string_test.cpp
+ * @author Derek Huang
+ * @brief string.h unit tests
+ * @copyright MIT License
+ */
+
+#include "oa/string.h"
+
+#include <algorithm>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "oa/common.h"    // for OA_IDENTITY()
+
+namespace {
+
+/**
+ * Test fixture for string tests.
+ */
+class StringTest : public ::testing::Test {};
+
+/**
+ * Test fixture template for compile-time string tests.
+ *
+ * @tparam T Input test type
+ */
+template <typename T>
+class StringTemplateTest : public StringTest {};
+
+/**
+ * Test fixture template for `to_upper` tests.
+ */
+class ToUpperTest : public StringTest {
+protected:
+  /**
+   * Convert the given character to uppercase in-place.
+   *
+   * @param c Input character
+   */
+  static void ToUpper(char& c) noexcept { c = oa::to_upper(c); }
+};
+
+/**
+ * Test that `to_upper()` works as expected with a printable ASCII string.
+ */
+TEST_F(ToUpperTest, PrintableStringTest)
+{
+  std::string a{"aHjs78S;ji1ER1nmp?"};
+  std::string b{"AHJS78S;JI1ER1NMP?"};
+  std::ranges::for_each(a, ToUpper);
+  EXPECT_EQ(a, b);
+}
+
+/**
+ * Test that `to_upper()` works as expected with non-printable characters.
+ */
+TEST_F(ToUpperTest, NonPrintableStringTest)
+{
+  // note: the hex characters purposefully have the leading bit set
+  std::string a{"\nsdf\r\tdf#O\xa7\x1e\xff"};
+  std::string b{"\nSDF\r\tDF#O\xa7\x1e\xff"};
+  std::ranges::for_each(a, ToUpper);
+  EXPECT_EQ(a, b);
+}
+
+/**
+ * Test fixture template for `to_lower` tests.
+ */
+class ToLowerTest : public StringTest {
+protected:
+  /**
+   * Convert the given character to lowercase in-place.
+   *
+   * @param c Input character
+   */
+  static void ToLower(char& c) noexcept { c = oa::to_lower(c); }
+};
+
+/**
+ * Test that `to_lower()` works as expected with a printable ASCII string.
+ */
+TEST_F(ToLowerTest, PrintableStringTest)
+{
+  std::string a{"Ihh7t8GAG9UIHJo;as"};
+  std::string b{"ihh7t8gag9uihjo;as"};
+  std::ranges::for_each(a, ToLower);
+  EXPECT_EQ(a, b);
+}
+
+/**
+ * Test that `to_lower()` works as expected with non-printable characters.
+ */
+TEST_F(ToLowerTest, NonPrintableStringTest)
+{
+  std::string a{"\xde\x21UIhj98\r\t\tA8U\n\x9a"};
+  std::string b{"\xde\x21uihj98\r\t\ta8u\n\x9a"};
+  std::ranges::for_each(a, ToLower);
+  EXPECT_EQ(a, b);
+}
+
+/**
+ * `to_upper()` compile-time character conversion test case input.
+ *
+ * @tparam a Input character
+ * @tparam b Expected output character
+ */
+template <char a, char b>
+struct to_upper_test_case {};
+
+/**
+ * Partial specialization for `to_upper_test_case<a, b>`.
+ *
+ * @tparam a Input character
+ * @tparam b Expected output character
+ */
+template <char a, char b>
+class StringTemplateTest<to_upper_test_case<a, b>> : public ToUpperTest {
+protected:
+  /**
+   * Invoke `to_upper(a)` at compile time and report the result.
+   */
+  void operator()() const
+  {
+    constexpr char c = oa::to_upper(a);
+    EXPECT_EQ(b, c);
+  }
+};
+
+/**
+ * `to_lower()` compile-time character conversion test case input.
+ *
+ * @tparam a Input character
+ * @tparam b Expected output character
+ */
+template <char a, char b>
+struct to_lower_test_case {};
+
+/**
+ * Partial specialization for `to_lower_test_case<a, b>`.
+ *
+ * @tparam a Input character
+ * @tparam b Expected output character
+ */
+template <char a, char b>
+class StringTemplateTest<to_lower_test_case<a, b>> : public ToLowerTest {
+protected:
+  /**
+   * Invoke `to_lower(a)` at compile time and report the result.
+   */
+  void operator()() const
+  {
+    constexpr char c = oa::to_lower(a);
+    EXPECT_EQ(b, c);
+  }
+};
+
+// instantiate StringTemplateTest
+TYPED_TEST_SUITE(
+  StringTemplateTest,
+  OA_IDENTITY(
+    ::testing::Types<
+      // to_upper() test cases
+      to_upper_test_case<'a', 'A'>,
+      to_upper_test_case<'$', '$'>,
+      to_upper_test_case<'H', 'H'>,
+      to_upper_test_case<'\n', '\n'>,
+      to_upper_test_case<'\xfa', '\xfa'>,
+      // to_lower() test cases
+      to_lower_test_case<'B', 'b'>,
+      to_lower_test_case<'?', '?'>,
+      to_lower_test_case<'c', 'c'>,
+      to_lower_test_case<'\x1e', '\x1e'>,
+      to_lower_test_case<'\t', '\t'>
+    >
+  )
+);
+
+/**
+ * Invoke the `StringTemplateTest<T>` test.
+ */
+TYPED_TEST(StringTemplateTest, Test)
+{
+  (*this)();
+}
+
+}  // namespace


### PR DESCRIPTION
# Summary

Adds `constexpr`, locale-independent functions that convert characters to lower or upper case.

These functions assume standard ASCII encoding and return the input unchanged if unrecognized. Compared to [`std::toupper()`](https://en.cppreference.com/cpp/string/byte/toupper) or [`std::tolower()`](https://en.cppreference.com/cpp/string/byte/tolower), these new functions are locale-independent, `constexpr`, and don't have any issues with needing to cast `int` to `unsigned char`. PR includes both run-time and compile-time tests to validate functionality.