### PR TITLE
add nightly package builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -93,7 +93,9 @@ jobs:
         run: |
           chmod +x build.sh
           ./build.sh -c Release -Ca \
-            -DCMAKE_UNITY_BUILD=$(echo ${{ matrix.unity }} | tr a-z A-Z)
+            -DCMAKE_UNITY_BUILD=$(echo ${{ matrix.unity }} | tr a-z A-Z) \
+            -DODIN_GITHUB_ACTIONS_RUNNER=${{ matrix.os }} \
+            -DODIN_GITHUB_ACTIONS_ARCH=$(echo ${{ runner.arch }} | tr A-Z a-z)
       # note: we don't have a nice wrapper script for this yet
       - name: Test
         run: ctest --test-dir build -j$(nproc) --output-on-failure
@@ -108,13 +110,8 @@ jobs:
         # only run on non-unity scheduled jobs as a nightly build
         # FIXME: add back github.event_name == 'schedule' check
         if: ${{ matrix.unity == 'off' }}
-        # ensure matrix runner name + runner arch are in file name
         run: |
-          cpack \
-            -DCPACK_SYSTEM_NAME=${{ matrix.os }}-$(echo ${{ runner.arch }} | tr A-Z a-z) \
-            -B build/packages \
-            -G "STGZ;TGZ" \
-            --config build/CPackConfig.cmake
+          cpack -B build/packages -G "STGZ;TGZ" --config build/CPackConfig.cmake
       # upload packages to the workflow page
       - name: Upload Artifacts
         # like the packaging step only run non-unity scheduled jobs

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -116,10 +116,9 @@ jobs:
           echo "cpack-sh=$(ls build/packages/*.sh)" >> "$GITHUB_OUTPUT"
           echo "cpack-tgz=$(ls build/packages/*.tar.gz)" >> "$GITHUB_OUTPUT"
       # upload packages to the workflow page
+      # note: only done when run on schedule for non-unity jobs
       - name: Upload STGZ
-        # like the packaging step only run non-unity scheduled jobs
-        # FIXME: add back github.event_name == 'schedule' check
-        if: ${{ matrix.unity == 'off' }}
+        if: ${{ github.event_name == 'schedule' && matrix.unity == 'off' }}
         uses: actions/upload-artifact@v7
         with:
           name: nightly-${{ matrix.os }}-sh
@@ -127,8 +126,7 @@ jobs:
           # don't archive the single file
           archive: false
       - name: Upload TGZ
-        # FIXME: add back github.event_name == 'schedule' check
-        if: ${{ matrix.unity == 'off' }}
+        if: ${{ github.event_name == 'schedule' && matrix.unity == 'off' }}
         uses: actions/upload-artifact@v7
         with:
           name: nightly-${{ matrix.os }}-tgz

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -103,3 +103,27 @@ jobs:
         run: sudo cmake --install build --component Runtime
       - name: Install Development
         run: sudo cmake --install build --component Development
+      # run CPack to create a self-extracting + standard tarball
+      - name: Package
+        # only run on non-unity scheduled jobs as a nightly build
+        # FIXME: add back github.event_name == 'schedule' check
+        if: ${{ matrix.unity == 'off' }}
+        # ensure matrix runner name + runner arch are in file name
+        run: |
+          cpack \
+            -DCPACK_SYSTEM_NAME=${{ matrix.os }}-$(echo ${{ runner.arch }} | tr A-Z a-z) \
+            -B build/packages \
+            -G "STGZ;TGZ" \
+            --config build/CPackConfig.cmake
+      # upload packages to the workflow page
+      - name: Upload Artifacts
+        # like the packaging step only run non-unity scheduled jobs
+        # FIXME: add back github.event_name == 'schedule' check
+        if: ${{ matrix.unity == 'off' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-${{ matrix.os }}
+          # only upload the .sh installer and .tar.gz
+          path: |
+            build/packages/*.sh
+            build/packages/*.tar.gz

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -107,20 +107,32 @@ jobs:
         run: sudo cmake --install build --component Development
       # run CPack to create a self-extracting + standard tarball
       - name: Package
+        id: cpack-package
         # only run on non-unity scheduled jobs as a nightly build
         # FIXME: add back github.event_name == 'schedule' check
         if: ${{ matrix.unity == 'off' }}
         run: |
           cpack -B build/packages -G "STGZ;TGZ" --config build/CPackConfig.cmake
+          # record .sh and .tar.gz paths in output for upload step
+          echo "cpack-sh=$(ls build/packages/*.sh)" >> "$GITHUB_OUTPUT"
+          echo "cpack-tgz=$(ls build/packages/*.tar.gz)" >> "$GITHUB_OUTPUT"
       # upload packages to the workflow page
-      - name: Upload Artifacts
+      - name: Upload STGZ
         # like the packaging step only run non-unity scheduled jobs
         # FIXME: add back github.event_name == 'schedule' check
         if: ${{ matrix.unity == 'off' }}
         uses: actions/upload-artifact@v7
         with:
-          name: nightly-${{ matrix.os }}
-          # only upload the .sh installer and .tar.gz
-          path: |
-            build/packages/*.sh
-            build/packages/*.tar.gz
+          name: nightly-${{ matrix.os }}-sh
+          path: ${{ steps.cpack-package.outputs.cpack-sh }}
+          # don't archive the single file
+          archive: false
+      - name: Upload TGZ
+        # FIXME: add back github.event_name == 'schedule' check
+        if: ${{ matrix.unity == 'off' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-${{ matrix.os }}-tgz
+          path: ${{ steps.cpack-package.outputs.cpack-tgz }}
+          # don't archive the single file
+          archive: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -108,8 +108,7 @@ jobs:
       # run CPack to create a self-extracting + standard tarball
       - name: Package
         id: cpack-package
-        # only run on non-unity scheduled jobs as a nightly build
-        # FIXME: add back github.event_name == 'schedule' check
+        # run for all non-unity jobs
         if: ${{ matrix.unity == 'off' }}
         run: |
           cpack -B build/packages -G "STGZ;TGZ" --config build/CPackConfig.cmake

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -211,3 +211,27 @@ jobs:
             --prefix "${{ env.ODIN_INSTALL_ROOT }}" `
             --config Release `
             --component Development
+      # run CPack to get the ZIP archive
+      - name: Package
+        id: cpack-package
+        # only run on non-unity scheduled jobs as a nightly build
+        # FIXME: add back github.event_name == 'schedule' check
+        if: ${{ matrix.unity == 'off' }}
+        run: |
+          $build_dir = "build_windows_$(OaPlatformTranslate "${{ matrix.arch }}")"
+          # note: for multi-config generators best to specify config with -C
+          cpack -B $build_dir/packages -G ZIP -C Release `
+            --config $build_dir/CPackConfig.cmake
+          # record .zip path in outupt for upload step
+          echo "cpack-zip=$(Get-ChildItem -Name $build_dir/*.zip)" >> "$GITHUB_OUTPUT"
+      # upload packages to the workflow page
+      - name: Upload ZIP
+        # like the packaging step only run non-unity scheduled jobs
+        # FIXME: add back github.event_name == 'schedule' check
+        if: ${{ matrix.unity == 'off' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-${{ matrix.os }}-zip
+          path: ${{ steps.cpack-package.outputs.cpack-zip }}
+          # already archived so don't archive
+          archive: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -218,6 +218,8 @@ jobs:
         # FIXME: add back github.event_name == 'schedule' check
         if: ${{ matrix.unity == 'off' }}
         run: |
+          # include PowerShell helpers
+          . .\tools\common.ps1
           $build_dir = "build_windows_$(OaPlatformTranslate "${{ matrix.arch }}")"
           # note: for multi-config generators best to specify config with -C
           cpack -B $build_dir/packages -G ZIP -C Release `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -225,9 +225,9 @@ jobs:
             --config $build_dir\CPackConfig.cmake
           # record .zip path in output for upload step
           # note: need to explicitly include packaging directory again
-          $step_output = "cpack-zip=$build_dir\packages"
-          $step_output += "$(Get-ChildItem -Name $build_dir\packages\*.zip)"
-          echo "cpack-zip=$step_output" >> "$GITHUB_OUTPUT"
+          $cpack_zip = "$build_dir\packages"
+          $cpack_zip += "$(Get-ChildItem -Name $build_dir\packages\*.zip)"
+          echo "cpack-zip=$cpack_zip" >> "$GITHUB_OUTPUT"
       # upload packages to the workflow page
       - name: Upload ZIP
         # like the packaging step only run non-unity scheduled jobs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -225,7 +225,7 @@ jobs:
             --config $build_dir\CPackConfig.cmake
           # record .zip path in output for upload step
           # note: need to explicitly include packaging directory again
-          $cpack_zip = "$build_dir\packages"
+          $cpack_zip = "$build_dir\packages\"
           $cpack_zip += "$(Get-ChildItem -Name $build_dir\packages\*.zip)"
           echo "cpack-zip=$cpack_zip" >> "$GITHUB_OUTPUT"
       # upload packages to the workflow page

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -179,7 +179,7 @@ jobs:
             "`"-DCMAKE_PREFIX_PATH=${{ env.ODIN_VENDOR_ROOT }}`"" `
             "`"-DXLLSDK_ROOT=${{ env.ODIN_VENDOR_ROOT }}\Excel2013XLLSDK`"" `
             "`"-DCMAKE_UNITY_BUILD=$ODIN_UNITY_BUILD`"" `
-            "`"-DODIN_GITHUB_ACTIONS_RUNNER`=${{ matrix.os }}"" `
+            "`"-DODIN_GITHUB_ACTIONS_RUNNER=${{ matrix.os }}`"" `
             "`"-DODIN_GITHUB_ACTIONS_ARCH=$(OaPlatformTranslate "${{ matrix.arch }}")`""
       # note: we don't have a nice wrapper script for this yet
       - name: Test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -214,8 +214,7 @@ jobs:
       # run CPack to get the ZIP archive
       - name: Package
         id: cpack-package
-        # only run on non-unity scheduled jobs as a nightly build
-        # FIXME: add back github.event_name == 'schedule' check
+        # run for all non-unity jobs
         if: ${{ matrix.unity == 'off' }}
         run: |
           # include PowerShell helpers
@@ -225,8 +224,10 @@ jobs:
           cpack -B $build_dir\packages -G ZIP -C Release `
             --config $build_dir\CPackConfig.cmake
           # record .zip path in output for upload step
-          echo "cpack-zip=$(Get-ChildItem -Name $build_dir\packages\*.zip)" >> `
-            "$GITHUB_OUTPUT"
+          # note: need to explicitly include packaging directory again
+          $step_output = "cpack-zip=$build_dir\packages"
+          $step_output += "$(Get-ChildItem -Name $build_dir\packages\*.zip)"
+          echo "cpack-zip=$step_output" >> "$GITHUB_OUTPUT"
       # upload packages to the workflow page
       - name: Upload ZIP
         # like the packaging step only run non-unity scheduled jobs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -222,10 +222,11 @@ jobs:
           . .\tools\common.ps1
           $build_dir = "build_windows_$(OaPlatformTranslate "${{ matrix.arch }}")"
           # note: for multi-config generators best to specify config with -C
-          cpack -B $build_dir/packages -G ZIP -C Release `
-            --config $build_dir/CPackConfig.cmake
-          # record .zip path in outupt for upload step
-          echo "cpack-zip=$(Get-ChildItem -Name $build_dir/*.zip)" >> "$GITHUB_OUTPUT"
+          cpack -B $build_dir\packages -G ZIP -C Release `
+            --config $build_dir\CPackConfig.cmake
+          # record .zip path in output for upload step
+          echo "cpack-zip=$(Get-ChildItem -Name $build_dir\packages\*.zip)" >> `
+            "$GITHUB_OUTPUT"
       # upload packages to the workflow page
       - name: Upload ZIP
         # like the packaging step only run non-unity scheduled jobs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -178,7 +178,9 @@ jobs:
           .\build -a $(OaPlatformTranslate "${{ matrix.arch }}") -c Release -Ca `
             "`"-DCMAKE_PREFIX_PATH=${{ env.ODIN_VENDOR_ROOT }}`"" `
             "`"-DXLLSDK_ROOT=${{ env.ODIN_VENDOR_ROOT }}\Excel2013XLLSDK`"" `
-            "`"-DCMAKE_UNITY_BUILD=$ODIN_UNITY_BUILD`""
+            "`"-DCMAKE_UNITY_BUILD=$ODIN_UNITY_BUILD`"" `
+            "`"-DODIN_GITHUB_ACTIONS_RUNNER`=${{ matrix.os }}"" `
+            "`"-DODIN_GITHUB_ACTIONS_ARCH=$(OaPlatformTranslate "${{ matrix.arch }}")`""
       # note: we don't have a nice wrapper script for this yet
       - name: Test
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -227,7 +227,7 @@ jobs:
           # note: need to explicitly include packaging directory again
           $cpack_zip = "$build_dir\packages\"
           $cpack_zip += "$(Get-ChildItem -Name $build_dir\packages\*.zip)"
-          echo "cpack-zip=$cpack_zip" >> "$GITHUB_OUTPUT"
+          echo "cpack-zip=$cpack_zip" >> "$env:GITHUB_OUTPUT"
       # upload packages to the workflow page
       - name: Upload ZIP
         # like the packaging step only run non-unity scheduled jobs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -229,10 +229,9 @@ jobs:
           $cpack_zip += "$(Get-ChildItem -Name $build_dir\packages\*.zip)"
           echo "cpack-zip=$cpack_zip" >> "$env:GITHUB_OUTPUT"
       # upload packages to the workflow page
+      # note: only done when run on schedule for non-unity jobs
       - name: Upload ZIP
-        # like the packaging step only run non-unity scheduled jobs
-        # FIXME: add back github.event_name == 'schedule' check
-        if: ${{ matrix.unity == 'off' }}
+        if: ${{ github.event_name == 'schedule' && matrix.unity == 'off' }}
         uses: actions/upload-artifact@v7
         with:
           name: nightly-${{ matrix.os }}-zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,30 @@ install(DIRECTORY static_data/calendars DESTINATION share/OA COMPONENT Runtime)
 set(CPACK_PACKAGE_NAME "OA")
 set(CPACK_PACKAGE_VENDOR "OA Developers")
 set(CPACK_PACKAGE_VERSION "${ODIN_VERSION}")
+# if running on GitHub Actions ODIN_GITHUB_ACTIONS_RUNNER and
+# ODIN_GITHUB_ACTIONS_ARCH need to be set. these will be used to set
+# CPACK_SYSTEM_NAME to influence CPACK_PACKAGE_FILE_NAME
+if(DEFINED ENV{GITHUB_ACTIONS})
+    if(NOT ODIN_GITHUB_ACTIONS_RUNNER)
+        message(
+            FATAL_ERROR
+            "ODIN_GITHUB_ACTIONS_RUNNER should be defined to the GitHub Actions "
+"runner image name, e.g. the value of jobs.<job_id>.runs-on"
+        )
+    endif()
+    if(NOT ODIN_GITHUB_ACTIONS_ARCH)
+        message(
+            FATAL_ERROR
+            "ODIN_GITHUB_ACTIONS_ARCH should be defined to the GitHub Actions "
+"runner architecture, e.g. runner.arch, or the build architecture itself, e.g. "
+"Win32, x64, etc."
+        )
+    endif()
+    set(
+        CPACK_SYSTEM_NAME
+        "${ODIN_GITHUB_ACTIONS_RUNNER}-${ODIN_GITHUB_ACTIONS_ARCH}"
+    )
+endif()
 set(CPACK_RESOURCE_FILE_LICENSE LICENSE)
 set(CPACK_RESOURCE_FILE_README README.md)
 # generate CPackConfig.cmake in build directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,3 +289,13 @@ install(
 # install rule for the calendar data. we consider this part of the Runtime
 # component because it is required for some libraries to function at runtime
 install(DIRECTORY static_data/calendars DESTINATION share/OA COMPONENT Runtime)
+
+# set variables for CPack
+# TODO: don't need to set CPACK_PACKAGE_NAME when project is renamed to OA
+set(CPACK_PACKAGE_NAME "OA")
+set(CPACK_PACKAGE_VENDOR "OA Developers")
+set(CPACK_PACKAGE_VERSION "${ODIN_VERSION}")
+set(CPACK_RESOURCE_FILE_LICENSE LICENSE)
+set(CPACK_RESOURCE_FILE_README README.md)
+# generate CPackConfig.cmake in build directory
+include(CPack)


### PR DESCRIPTION
# Summary

Modification to GitHub Actions workflows to create and upload packages for every daily scheduled run.

We use [CPack](https://cmake.org/cmake/help/latest/manual/cpack.1.html) to create packages, i.e. a self-extracting (works as a CLI installer) and a standard tar.gz for Linux, and a ZIP archive for Windows. Packaging is done for each non-unity build run on CI but actual artifact upload will only be done for every daily scheduled build. Therefore, pull requests/feature branch builds will perform the packaging, but only the scheduled daily builds will have any artifacts available for download from their GitHub Actions pages.

These changes make it easy to go to the workflow result pages and download periodic nightly builds.