### PR TITLE
fix conditional `<cerrno>` include in paths_test.cpp

### DIFF
--- a/src/unit_test/config/paths_test.cpp
+++ b/src/unit_test/config/paths_test.cpp
@@ -19,9 +19,9 @@
 #endif  // !defined(_WIN32)
 
 // again, only need errno when not on Windows
-#ifdef _GNU_SOURCE
+#ifndef _WIN32
 #include <cerrno>
-#endif  // _GNU_SOURCE
+#endif  // _WIN32
 #include <filesystem>
 #include <system_error>
 


### PR DESCRIPTION
## Summary

Fixes the conditional include of `<cerrno>` in `paths_test.cpp` as testing for `_GNU_SOURCE` is not relevant here,.

We only want to include `<cerrno>` when not compiling on Windows so `#ifndef _WIN32` is more pertinent.