### PR TITLE
update GoogleTest to >=1.11.0 + fix MSVC warning flag typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,9 @@ find_package(magic_enum 0.8.1 REQUIRED)
 message(STATUS "Magic Enum version: ${magic_enum_VERSION}")
 
 # find GoogleTest
-find_package(GTest 1.8)
+# note: bumped from the ancient 1.8 as <1.11.0 uses std::result_of in
+# gmock-actions.h which was removed in C++20
+find_package(GTest 1.11.0)
 if(GTest_FOUND)
     # set GTest_VERSION approximately if GTest found using FindGTest.cmake
     # note: if GTest_VERSION already set nothing is done
@@ -156,7 +158,7 @@ if(MSVC)
         /W4 /MP
         # C4668: macro not defined and replaced with 0. this is turned on with
         # /Wall, but since we are using /W4, we explicitly enable
-        /w34668
+        /wd4668
         # specific /Wall warnings we are ok with disabling
         # typically don't care if unreferenced inline functions are removed
         /wd4514


### PR DESCRIPTION
## Summary

Bump GoogleTest minimum version to 1.11.0 for C++20 support + fix MSVC warning flag typo.

GoogleTest 1.10.0 uses `std::result_of` in `gmock-actions.h` which was removed in C++20. The MSVC warning flag was intended to disable [C4668](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4668) but due it being misspelled as `/w34668` instead of `/wd4668`, C4668 was instead treated as a level 3 warning, which explains why it was being emitted in #122 despite use of `/wd4668` on the SWIG module target.