### PR TITLE
OXL API excel_base linker error + IWYU fix

### DIFF
--- a/src/oxl/CMakeLists.txt
+++ b/src/oxl/CMakeLists.txt
@@ -21,8 +21,10 @@ if(XLLSDK_FOUND)
         # note: not installable just yet
         $<INSTALL_INTERFACE:include>
     )
-    # excel_base.cpp uses helpers/utils.h
-    target_link_libraries(oxl_api PRIVATE oa_helpers)
+    # excel_base.cpp uses helpers/utils.h and time/date.h
+    target_link_libraries(oxl_api PRIVATE oa_helpers oa_time)
+    # excel_base.h exposes derived_time headers
+    target_link_libraries(oxl_api PUBLIC oa_derived_time)
     # xl_utils.h uses Excel12f() and needs XLCALL.H and FRAMEWRK.H so we can't
     # make the linkage of the XLL SDK libraries private
     target_link_libraries(oxl_api PUBLIC XLLSDK::Framework XLLSDK::SDK)

--- a/src/oxl/xl_api/excel_base.cpp
+++ b/src/oxl/xl_api/excel_base.cpp
@@ -1,10 +1,17 @@
 #include "excel_base.h"
 
+#include <string>
+#include <memory>
+#include <vector>
+
+#include "derived_time/cashflow_gen/cashflow_struct.h"
+#include "derived_time/date_formula/business_date_formula.h"
+#include "derived_time/derived_time_enums.h"
 #include "helpers/utils.h"
 #include "oxl/xl_api/cache_xl_obj.h"
 #include "oxl/xl_api/xl_array.h"
-#include "oxl/xl_api/xloper_converter.h"
 #include "oxl/xl_api/xl_utils.h"
+#include "oxl/xl_api/xloper_converter.h"
 #include "time/date.h"
 
 namespace oxl::xl_api
@@ -14,7 +21,7 @@ namespace oxl::xl_api
 		return std::make_shared<XlArray>(XLoperObj::LPXloperToXlArray(data_range));
 	}
 
-	xl_api::XlArray ConvertCFStructToXlArray(const std::vector<oa::derived_time::CashflowStruct>& cf_struct_array, oa::derived_time::CashflowType cf_type)
+	XlArray ConvertCFStructToXlArray(const std::vector<oa::derived_time::CashflowStruct>& cf_struct_array, oa::derived_time::CashflowType cf_type)
 	{
 
 		switch(cf_type)
@@ -22,7 +29,7 @@ namespace oxl::xl_api
 
 			case oa::derived_time::CashflowType::kFixed:
 			{
-				xl_api::XlArray xl_results(cf_struct_array.size() + 1, 14);
+				XlArray xl_results(cf_struct_array.size() + 1, 14);
 				xl_results[0] = {"Unadj_Start_Date", "Unadj_End_Date", "Start_Date", "End_Date", "Fixing_Date", "Payment_Date", "Notional", "Rate", "Fwd_Cashflow_PV", "Cashflow_NPV", "Day_Count", "Day_Count_Fraction", "Currency", "Cashflow_Type"};
 				//may want to put this into a seperate function that converts different cashflows into output idk feel free to comment.
 				for(size_t i = 1; i < xl_results.rows(); i++) {
@@ -49,7 +56,7 @@ namespace oxl::xl_api
 
 			default:
 			{
-				xl_api::XlArray xl_results(1,1);
+				XlArray xl_results(1,1);
 				xl_results(0,0) = std::string("Invalid input was given");
 				return xl_results;
 			}
@@ -58,28 +65,28 @@ namespace oxl::xl_api
 		}
 	}
 
-	std::shared_ptr<xl_api::XlDictionary> RetrieveXLDict(const xl_api::XlDictionary& dictionary, const std::string& chached_str)
+	std::shared_ptr<XlDictionary> RetrieveXLDict(const XlDictionary& dictionary, const std::string& chached_str)
 	{
 
 		auto fixing_dict_handle = std::get<std::string>(dictionary[chached_str]);
-		auto fixing_dict_str_key = oxl::xl_api::XlCacheObj::GetKeyFromHandle(fixing_dict_handle);
-		if (!xl_api::XlCacheObj::IsDictionary(fixing_dict_str_key))
+		auto fixing_dict_str_key = XlCacheObj::GetKeyFromHandle(fixing_dict_handle);
+		if (!XlCacheObj::IsDictionary(fixing_dict_str_key))
 		{
 			throw std::runtime_error(std::format("{} is not a valid cached dictionary handle please check input!", fixing_dict_handle));
 		}
 		auto cache_variant = XlCacheObj::GetVariant(fixing_dict_str_key);
-		auto xl_dictionary = std::get<std::shared_ptr<xl_api::XlDictionary>>(cache_variant);
+		auto xl_dictionary = std::get<std::shared_ptr<XlDictionary>>(cache_variant);
 		return xl_dictionary;
 
 
 	}
 
-	bool ValidBusinessDateDictionary(const xl_api::XlDictionary& dict)
+	bool ValidBusinessDateDictionary(const XlDictionary& dict)
 	{
 		return dict.Contains("Days") && dict.Contains("Calendar");
 	}
 
-	oa::derived_time::BusinessDateFormula GetBusinessDateFormulaFromDict(const xl_api::XlDictionary& dict, const std::string& date_rule_key)
+	oa::derived_time::BusinessDateFormula GetBusinessDateFormulaFromDict(const XlDictionary& dict, const std::string& date_rule_key)
 	{
 		auto date_rule_dict = RetrieveXLDict(dict, date_rule_key);
 		if (!ValidBusinessDateDictionary(*date_rule_dict))
@@ -91,7 +98,7 @@ namespace oxl::xl_api
 		return oa::derived_time::BusinessDateFormula(num_of_days, calendar);
 	}
 
-	bool ValidCashflowGenDictionary(const xl_api::XlDictionary& dictionary) {
+	bool ValidCashflowGenDictionary(const XlDictionary& dictionary) {
 		return dictionary.Contains("Start_Date") && dictionary.Contains("Mat_Date") && dictionary.Contains("Notional") && dictionary.Contains("Rate") && dictionary.Contains("Day_Count_Frac") && dictionary.Contains("Frequency") && dictionary.Contains("Date_Dir") && dictionary.Contains("Stub_Type");
 	}
 }

--- a/src/oxl/xl_api/excel_base.h
+++ b/src/oxl/xl_api/excel_base.h
@@ -2,6 +2,7 @@
 #define OXL_XL_API_EXCEL_BASE_H_
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "derived_time/cashflow_gen/cashflow_struct.h"
@@ -16,11 +17,11 @@ struct xloper12;
 namespace oxl::xl_api
 {
 	std::shared_ptr<XlArray> ToXLArrayPtr(const xloper12* data_range);
-	xl_api::XlArray ConvertCFStructToXlArray(const std::vector<oa::derived_time::CashflowStruct>& cf_struct_array, oa::derived_time::CashflowType cf_type);
-	std::shared_ptr<xl_api::XlDictionary> RetrieveXLDict(const xl_api::XlDictionary& dictionary, const std::string& chached_str);
-	bool ValidBusinessDateDictionary(const xl_api::XlDictionary& dictionary);
-	bool ValidCashflowGenDictionary(const xl_api::XlDictionary& dictionary);
-	oa::derived_time::BusinessDateFormula GetBusinessDateFormulaFromDict(const xl_api::XlDictionary& dict, const std::string& date_rule_key);
+	XlArray ConvertCFStructToXlArray(const std::vector<oa::derived_time::CashflowStruct>& cf_struct_array, oa::derived_time::CashflowType cf_type);
+	std::shared_ptr<XlDictionary> RetrieveXLDict(const XlDictionary& dictionary, const std::string& chached_str);
+	bool ValidBusinessDateDictionary(const XlDictionary& dictionary);
+	bool ValidCashflowGenDictionary(const XlDictionary& dictionary);
+	oa::derived_time::BusinessDateFormula GetBusinessDateFormulaFromDict(const XlDictionary& dict, const std::string& date_rule_key);
 }
 
 #endif // !OXL_XL_API_EXCEL_BASE_H_


### PR DESCRIPTION
## Summary

Fixes OXL API `excel_base.cpp` linkage issue that appeared when using VS 2026 on GitHub Actions + IWYU fixes.

Since June 10 it appears that the `windows-2025` GitHub Actions builds have been redirected to `windows-2025-vs2026` which means that the project is building with VS 2026 on CI now. However, using VS 2026 has revealed [a linker error](https://github.com/Mjang714/OdinAnalytics/actions/runs/27315640088/job/80695461409) complaining about `~BusinessDateFormula()` already having been defined. Although initially it appeared like a VS 2026 bug, investigation revealed this was because `excel_base.(h|cpp)` use headers from `oa_derived_time` and `oa_time`, but the relevant target (and therefore usage) dependencies were not added in the CMake configuration to the `oxl_api` target.

Since `BusinessDateFormula` is returned from one of the `excel_base.h` functions, a dtor must be generated (object has to be destructed at some point). However, since `oa_derived_time` usage in shared library mode required `OA_DERIVED_TIME_DLL` to be defined, and the appropriate usage requirements were not specified by linking against `oa_derived_time` in the CMake config, it's likely that `oxl_api` objects were built without `OA_DERIVED_TIME_DLL`, so `BusinessDateFormula` and other types were not marked as `__declspec(dllimport)` appropriately. Therefore, MSVC is correct to generate a dtor for ODR usage, but the "correct" one was defined in `oa_derived_time`, so when the `oxl.xll` linking is done, the ODR violation is discovered.

We are not able to check the ODR violation directly by building `oxl_api` since it is built as a static library; i.e. it is just an object archive and the final linking and symbol resolutions haven't yet been done.