### PR TITLE
update CMake Unix wrappers

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -111,9 +111,9 @@ jobs:
             -DCMAKE_UNITY_BUILD=$(echo ${{ matrix.unity }} | tr a-z A-Z) \
             -DODIN_GITHUB_ACTIONS_RUNNER=${{ matrix.os }} \
             -DODIN_GITHUB_ACTIONS_ARCH=$(echo ${{ runner.arch }} | tr A-Z a-z)
-      # note: we don't have a nice wrapper script for this yet
+      # note: test parallelism level is -j$(nproc) by default
       - name: Test
-        run: ctest --test-dir build -j$(nproc) --output-on-failure
+        run: ./check.sh -Ct --output-on-failure
       # install Runtime and Development components separately
       # note: only good as a smoke test. need sudo due to /usr/local install
       - name: Install Runtime

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,7 +113,9 @@ jobs:
             -DODIN_GITHUB_ACTIONS_ARCH=$(echo ${{ runner.arch }} | tr A-Z a-z)
       # note: test parallelism level is -j$(nproc) by default
       - name: Test
-        run: ./check.sh -Ct --output-on-failure
+        run: |
+          chmod +x check.sh
+          ./check.sh -Ct --output-on-failure
       # install Runtime and Development components separately
       # note: only good as a smoke test. need sudo due to /usr/local install
       - name: Install Runtime

--- a/build.sh
+++ b/build.sh
@@ -54,64 +54,66 @@ parse_args() {
     for ARG in $@
     do
         case $ARG in
-            # break early to print usage
-            -h | --help)
-                BUILD_ACTION=print_usage
-                return 0
-                ;;
-            # set build output directory
-            -o | --output-dir)
-                PARSE_ACTION=output_dir
+        # break early to print usage
+        -h | --help)
+            BUILD_ACTION=print_usage
+            return 0
+            ;;
+        # set build output directory
+        -o | --output-dir)
+            PARSE_ACTION=output_dir
+            ;;
+        # set build configuration
+        -c | --config)
+            PARSE_ACTION=build_config
+            ;;
+        # collect CMake configure args
+        -Ca | --cmake-args)
+            PARSE_ACTION=cmake_args
+            ;;
+        # collect CMake build args
+        -Cb | --cmake-build-args)
+            PARSE_ACTION=cmake_build_args
+            ;;
+        # operate according to PARSE_ACTION
+        *)
+            case $PARSE_ACTION in
+            # set build output dir
+            output_dir)
+                BUILD_OUTPUT_DIR=$ARG
                 ;;
             # set build configuration
-            -c | --config)
-                PARSE_ACTION=build_config
+            build_config)
+                BUILD_CONFIG=$ARG
                 ;;
-            # collect CMake configure args
-            -Ca | --cmake-args)
-                PARSE_ACTION=cmake_args
-                ;;
-            # collect CMake build args
-            -Cb | --cmake-build-args)
-                PARSE_ACTION=cmake_build_args
-                ;;
-            # operate according to PARSE_ACTION
-            *)
-                # set build output dir
-                if [ "$PARSE_ACTION" = output_dir ]
+            # update CMake configure args
+            cmake_args)
+                # assign directly if empty to prevent adding extra space
+                if [ -z "$CMAKE_ARGS" ]
                 then
-                    BUILD_OUTPUT_DIR=$ARG
-                # set build configuration
-                elif [ "$PARSE_ACTION" = build_config ]
-                then
-                    BUILD_CONFIG=$ARG
-                # update CMake configure args
-                elif [ "$PARSE_ACTION" = cmake_args ]
-                then
-                    # assign directly if empty to prevent adding extra space
-                    if [ -z "$CMAKE_ARGS" ]
-                    then
-                        CMAKE_ARGS=$ARG
-                    else
-                        CMAKE_ARGS="$CMAKE_ARGS $ARG"
-                    fi
-                # update CMake build args
-                elif [ "$PARSE_ACTION" = cmake_build_args ]
-                then
-                    # assign directly if empty to prevent adding extra space
-                    if [ -z "$CMAKE_BUILD_ARGS" ]
-                    then
-                        CMAKE_BUILD_ARGS=$ARG
-                    else
-                        CMAKE_BUILD_ARGS="$CMAKE_BUILD_ARGS $ARG"
-                    fi
-                # error otherwise
+                    CMAKE_ARGS=$ARG
                 else
-                    echo "Error: Unknown option '$ARG'." \
-                        "Try $PROGNAME --help for usage."
-                    return 1
+                    CMAKE_ARGS="$CMAKE_ARGS $ARG"
                 fi
                 ;;
+            # update CMake build args
+            cmake_build_args)
+                # assign directly if empty to prevent adding extra space
+                if [ -z "$CMAKE_BUILD_ARGS" ]
+                then
+                    CMAKE_BUILD_ARGS=$ARG
+                else
+                    CMAKE_BUILD_ARGS="$CMAKE_BUILD_ARGS $ARG"
+                fi
+                ;;
+            # error otherwise
+            *)
+                echo "Error: Unknown option '$ARG'." \
+                    "Try $PROGNAME --help for usage."
+                return 1
+                ;;
+            esac
+            ;;
         esac
     done
     return 0

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/bash
+#
+# CTest wrapper script for OdinAnalytics.
+#
+# Author: Derek Huang
+# Copyright: MIT License
+#
+
+# program name ($0 refers to current function)
+PROGNAME=$0
+# current action to take, argument parsing mode
+TEST_ACTION=
+PARSE_ACTION=
+# CTest arguments
+# note: by default we are already using -j$(nproc)
+CTEST_ARGS="-j$(nproc)"
+# default build directory
+BUILD_DIR=build
+
+##
+# Print testing wrapper usage.
+#
+print_usage() {
+    echo "Usage: $PROGNAME" \
+        "[-h] [-b BUILD_DIR] [-j[ ]PROCS] [-p] [-Ct CTEST_ARGS]"
+    echo
+    echo "Test driver script for OdinaAnalytics *nix builds."
+    echo
+    echo "Only supports single-configuration CMake generators, e.g. Makefile"
+    echo "generators or Ninja, with \"Unix Makefiles\" as the default."
+    echo
+    echo "CTest will run \$(nproc) tests in parallel by default unless the "
+    echo "-j, --parallel argument is provided. To print short progress output "
+    echo "the -p, --progress option can be specified."
+    echo
+    echo "Options:"
+    echo "  -h,  --help                     Print this usage"
+    echo "  -b,  --build-dir BUILD_DIR      Build directory, default $BUILD_DIR"
+    echo "  -j[ ]PROCS, --parallel PROCS    Test parallelism, default $(nproc)"
+    echo "  -p, --progress                  Print short progress output"
+    echo "  -Ct, --ctest-args CTEST_ARGS    Additional CTest arguments"
+}
+
+##
+# Parse incoming arguments and populate CTest arguments.
+#
+# Arguments:
+#   List of command-line arguments
+#
+parse_args() {
+    for ARG in $@
+    do
+        case $ARG in
+        # -h, --help
+        -h | --help)
+            TEST_ACTION=print_usage
+            return 0
+            ;;
+        # -b, --build-dir
+        -b | --build-dir)
+            PARSE_ACTION=build_dir
+            ;;
+        # -j, --parallel
+        -j | --parallel)
+            PARSE_ACTION=parallel
+            ;;
+        # -j[0-9]+
+        -j*)
+            CTEST_ARGS="$CTEST_ARGS $ARG"
+            ;;
+        # -p, --progress
+        -p | --progress)
+            CTEST_ARGS="$CTEST_ARGS --progress"
+            ;;
+        # -Ct, --ctest-args
+        -Ct | --ctest-args)
+            PARSE_ACTION=ctest_args
+            ;;
+        # operate according to PARSE_ACTION
+        *)
+            # build directory to test
+            case $PARSE_ACTION in
+            build_dir)
+                BUILD_DIR=$ARG
+                ;;
+            parallel)
+                CTEST_ARGS="$CTEST_ARGS -j$ARG"
+                ;;
+            ctest_args)
+                CTEST_ARGS="$CTEST_ARGS $ARG"
+                ;;
+            # no parse action
+            *)
+                echo "Error: Unkown option '$ARG'." \
+                    "Try $PROGNAME --help for usage."
+                return 1
+            esac
+            ;;
+        esac
+    done
+}
+
+##
+# Main function for the script.
+#
+# Arguments:
+#   List of command-line arguments
+#
+main() {
+    # parse arguments + exit on error
+    parse_args "$@"
+    if [ $? -ne 0 ]
+    then
+        return $?
+    fi
+    # print usage or run tests
+    if [ "$TEST_ACTION" == "print_usage" ]
+    then
+        print_usage
+    else
+        ctest --test-dir "$BUILD_DIR" $CTEST_ARGS
+    fi
+    # use last command exit status as return
+    return $?
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a `check.sh` script to wrap the CTest command with `-j$(nproc)`, using this script in CI, and tweaks `build.sh`.

The `check.sh` script is a convenience for running CTest locally to shorten `ctest --test-dir build -j22 --progress`.